### PR TITLE
Add .gitattributes for proper eol conversion in bat, sh, rst, and py files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.bat   eol=crlf
+*.sh    eol=lf
+*.rst   eol=text
+*.py    eol=text


### PR DESCRIPTION
See:

http://www.kernel.org/pub/software/scm/git/docs/gitattributes.html#_tt_eol_tt
