### PR TITLE
Python Debug Improvement

### DIFF
--- a/io_scene_nif/__init__.py
+++ b/io_scene_nif/__init__.py
@@ -56,8 +56,11 @@ bl_info = {
     "support": "COMMUNITY",
     "category": "Import-Export"}
 
-from . import nif_debug
-nif_debug.startdebug()
+try:
+    from . import nif_debug
+    nif_debug.startdebug()
+except:
+    print("Failed to load debug module")
 
 import logging
 import sys

--- a/io_scene_nif/nif_debug/__init__.py
+++ b/io_scene_nif/nif_debug/__init__.py
@@ -6,15 +6,18 @@ PYDEV_SOURCE_DIR = ""
 def startdebug():
 
     try:
-        PYDEV_SOURCE_DIR = os.environ['PYDEV_SOURCE_DIR']
+        pydev_src = os.environ['PYDEVDEBUG']
         
-        if sys.path.count(PYDEV_SOURCE_DIR) > 0:
-            sys.path.append(PYDEV_SOURCE_DIR)
+        if (sys.path.count(pydev_src) < 1) :
+             sys.path.append(pydev_src)
              
         import pydevd
+    except:
+        print("Could not find Python Remote Debugger")
+        pass
+    
+    try:
         pydevd.settrace(None, True, True, 5678, False, False)
-     
     except:    
         print("Unable to connect to Remote debugging server")
-        print("PYDEV_SOURCE_DIR := " + PYDEV_SOURCE_DIR)
         pass


### PR DESCRIPTION
Removes hard coded path to debug module and now uses the enviromental variable %PYDEVDEBUG%. 

Debugging is now enabled by default so developer no longer need to enable it or deal with resulting file change that would be picked up during the commit process.

On the user side, errors are silently printed to console which is expected behaviour for release builds. 
