### PR TITLE
Fix catch for exporting a parented mesh with no armature modifier

### DIFF
--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -157,17 +157,26 @@ class NifExport(NifCommon):
 
 
                 if b_obj.type == 'MESH':
+                    b_armature_modifier = None
                     b_obj_name = b_obj.name
                     if b_obj.parent:
-                        b_obj_parent = b_obj.parent.name
-                        if bpy.data.objects[b_obj_name].modifiers[b_obj_parent].use_bone_envelopes:
+                        for b_mod in bpy.data.objects[b_obj_name].modifiers:
+                            if b_mod.type == 'ARMATURE':
+                                b_armature_modifier = b_mod.name
+                                if b_mod.use_bone_envelopes:
+                                    raise nif_utils.NifError(
+                                            "'%s': Cannot export envelope skinning."
+                                            " If you have vertex groups,"
+                                            " turn off envelopes. If you don't have vertex"
+                                            " groups, select the bones one by one press W"
+                                            " to convert their envelopes to vertex weights,"
+                                            " and turn off envelopes."
+                                            % b_obj.name)
+                        if not b_armature_modifier:
                             raise nif_utils.NifError(
-                                    "'%s': Cannot export envelope skinning."
-                                    " If you have vertex groups,"
-                                    " turn off envelopes. If you don't have vertex"
-                                    " groups, select the bones one by one press W"
-                                    " to convert their envelopes to vertex weights,"
-                                    " and turn off envelopes."
+                                    "'%s': is parented but does not have"
+                                    " the armature modifier set. This will"
+                                    " cause animations to fail."
                                     % b_obj.name)
 
                 # check for non-uniform transforms


### PR DESCRIPTION
applied. submitted by misternad in irc Ref #170 
