### PR TITLE
Bug/lost weight log formatting error

### DIFF
--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -455,7 +455,7 @@ class Mesh:
                                 NifLog.warn("Using less than 24 bones per partition on Skyrim export."
                                             "Set it to 24 to get higher quality skin partitions.")
                         if lostweight > NifOp.props.epsilon:
-                            NifLog.warn(f"Lost {lostweight:s} in vertex weights while creating a skin partition for Blender object '{b_obj.name}' (nif block '{trishape.name}')")
+                            NifLog.warn(f"Lost {lostweight:f} in vertex weights while creating a skin partition for Blender object '{b_obj.name}' (nif block '{trishape.name}')")
 
                     if isinstance(skininst, NifFormat.BSDismemberSkinInstance):
                         partitions = skininst.partitions

--- a/io_scene_niftools/operators/common_op.py
+++ b/io_scene_niftools/operators/common_op.py
@@ -124,7 +124,7 @@ class CommonEGM:
 
 class CommonKF:
     # Default file name extension.
-    filename_ext = ".egm"
+    filename_ext = ".kf"
 
     # File name filter for file select dialog.
     filter_glob: bpy.props.StringProperty(

--- a/io_scene_niftools/operators/nif_export_op.py
+++ b/io_scene_niftools/operators/nif_export_op.py
@@ -43,7 +43,7 @@ from bpy_extras.io_utils import ExportHelper
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.nif_export import NifExport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonExportScale, CommonKF
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonExportScale, CommonNif
 
 
 def _game_to_enum(game):
@@ -53,7 +53,7 @@ def _game_to_enum(game):
     return enum
 
 
-class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonExportScale, CommonKF):
+class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonExportScale, CommonNif):
     """Operator for saving a nif file."""
 
     # Name of function for calling the nif export operators.


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
**[Overview of the content of the pull request]**
Excution failure due to log formatting

##  Detailed Description
**[List of functional updates]**
- Logging of lost vertex weighting is failing due to incorrectly formatted message string, should be float instead of string.
- Fixed issue with .nif extension not being set on export
- Fixed issue with .kf being mapped to .egm

## Fixes Known Issues
**[Ordered list of issues fixed by this PR]**
n/a

## Documentation
**[Overview of updates to documentation]**
n/a

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**


### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
