### PR TITLE
Fix up scale correction

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_12" default="true" project-jdk-name="Python 3.7 (blender_nif_plugin)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7" project-jdk-type="Python SDK" />
   <component name="PythonCompatibilityInspectionAdvertiser">
     <option name="version" value="3" />
   </component>

--- a/io_scene_niftools/egm_import.py
+++ b/io_scene_niftools/egm_import.py
@@ -39,12 +39,11 @@
 
 import bpy
 
-from io_scene_niftools import NifLog
 from io_scene_niftools.file_io.egm import EGMFile
 from io_scene_niftools.modules.nif_import.animation.morph import MorphAnimation
 from io_scene_niftools.nif_common import NifCommon
 from io_scene_niftools.utils.singleton import NifOp, EGMData
-from io_scene_niftools.utils.logging import NifError
+from io_scene_niftools.utils.logging import NifError, NifLog
 
 
 class EgmImport(NifCommon):
@@ -64,7 +63,7 @@ class EgmImport(NifCommon):
             if egm_path:
                 EGMData.init(EGMFile.load_egm(egm_path))
                 # scale the data
-                EGMData.data.apply_scale(NifOp.props.scale_correction_import)
+                EGMData.data.apply_scale(NifOp.props.scale_correction)
                 # TODO [morph][egm] if there is an egm, the assumption is that there is only one mesh in the nif
                 # grab the active object
                 b_obj = bpy.context.view_layer.objects.active

--- a/io_scene_niftools/kf_import.py
+++ b/io_scene_niftools/kf_import.py
@@ -41,15 +41,13 @@ import os
 
 import pyffi.spells.nif.fix
 
-import io_scene_niftools.utils.logging
-from io_scene_niftools import NifLog
 from io_scene_niftools.file_io.kf import KFFile
 from io_scene_niftools.modules.nif_export import armature
 from io_scene_niftools.modules.nif_import.animation.transform import TransformAnimation
 from io_scene_niftools.nif_common import NifCommon
 from io_scene_niftools.utils import math
 from io_scene_niftools.utils.singleton import NifOp
-from io_scene_niftools.utils.logging import NifError
+from io_scene_niftools.utils.logging import NifLog, NifError
 
 
 class KfImport(NifCommon):
@@ -68,7 +66,7 @@ class KfImport(NifCommon):
             kf_files = [os.path.join(dirname, file.name) for file in NifOp.props.files if file.name.lower().endswith(".kf")]
             b_armature = math.get_armature()
             if not b_armature:
-                raise io_scene_niftools.utils.logging.NifError("No armature was found in scene, can not import KF animation!")
+                raise NifError("No armature was found in scene, can not import KF animation!")
 
             # the axes used for bone correction depend on the armature in our scene
             math.set_bone_orientation(b_armature.data.niftools.axis_forward, b_armature.data.niftools.axis_up)
@@ -80,7 +78,7 @@ class KfImport(NifCommon):
 
                 # use pyffi toaster to scale the tree
                 toaster = pyffi.spells.nif.NifToaster()
-                toaster.scale = NifOp.props.scale_correction_import
+                toaster.scale = NifOp.props.scale_correction
                 pyffi.spells.nif.fix.SpellScale(data=kfdata, toaster=toaster).recurse()
 
                 # calculate and set frames per second

--- a/io_scene_niftools/modules/nif_export/property/texture/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/__init__.py
@@ -39,12 +39,10 @@
 
 import bpy
 
-import io_scene_niftools.utils.logging
 from io_scene_niftools.modules.nif_export.animation.texture import TextureAnimation
 from io_scene_niftools.modules.nif_export.property import texture
 from io_scene_niftools.modules.nif_export.property.texture.writer import TextureWriter
-from io_scene_niftools.utils import math
-from io_scene_niftools.utils.logging import NifLog
+from io_scene_niftools.utils.logging import NifLog, NifError
 
 
 class TextureSlotManager:
@@ -90,8 +88,8 @@ class TextureSlotManager:
         elif isinstance(uv_node, bpy.types.ShaderNodeTexCoord):
             return "REFLECT"
         else:
-            raise io_scene_niftools.utils.logging.NifError(f"Unsupported vector input for {b_texture_node.name} in material '{self.b_mat.name}''.\n"
-                                     f"Expected 'UV Map' or 'Texture Coordinate' nodes")
+            raise NifError(f"Unsupported vector input for {b_texture_node.name} in material '{self.b_mat.name}''.\n"
+                           f"Expected 'UV Map' or 'Texture Coordinate' nodes")
 
     @staticmethod
     def get_used_textslots(b_mat):
@@ -122,12 +120,12 @@ class TextureSlotManager:
                 if slot_name in b_texture_node.label:
                     # slot has already been populated
                     if self.slots[slot_name]:
-                        raise io_scene_niftools.utils.logging.NifError(f"Multiple {slot_name} textures in material '{b_mat.name}''.\n"
-                                                 f"Make sure there is only one texture node labeled as '{slot_name}'")
+                        raise NifError(f"Multiple {slot_name} textures in material '{b_mat.name}''.\n"
+                                       f"Make sure there is only one texture node labeled as '{slot_name}'")
                     # it's a new slot so store it
                     self.slots[slot_name] = b_texture_node
                     break
             # unsupported texture type
             else:
-                raise io_scene_niftools.utils.logging.NifError(f"Do not know how to export texture node '{b_texture_node.name}' in material '{b_mat.name}'."
-                                         f"Delete it or change its label.")
+                raise NifError(f"Do not know how to export texture node '{b_texture_node.name}' in material '{b_mat.name}'."
+                               f"Delete it or change its label.")

--- a/io_scene_niftools/nif_export.py
+++ b/io_scene_niftools/nif_export.py
@@ -282,16 +282,16 @@ class NifExport(NifCommon):
             """
 
             # apply scale
-            if abs(NifOp.props.scale_correction_export) > NifOp.props.epsilon:
-                NifLog.info(f"Applying scale correction {NifOp.props.scale_correction_export}")
+            if abs(NifOp.props.scale_correction) > NifOp.props.epsilon:
+                NifLog.info(f"Applying scale correction {NifOp.props.scale_correction}")
                 data.roots = [root_block]
                 toaster = pyffi.spells.nif.NifToaster()
-                toaster.scale = NifOp.props.scale_correction_export
+                toaster.scale = 1 / NifOp.props.scale_correction
                 pyffi.spells.nif.fix.SpellScale(data=data, toaster=toaster).recurse()
 
                 # also scale egm
                 if EGMData.data:
-                    EGMData.data.apply_scale(NifOp.props.scale_correction_export)
+                    EGMData.data.apply_scale(1 / NifOp.props.scale_correction)
 
             # generate mopps (must be done after applying scale!)
             if bpy.context.scene.niftools_scene.game in ('OBLIVION', 'FALLOUT_3', 'SKYRIM'):

--- a/io_scene_niftools/nif_export.py
+++ b/io_scene_niftools/nif_export.py
@@ -282,16 +282,18 @@ class NifExport(NifCommon):
             """
 
             # apply scale
-            if abs(NifOp.props.scale_correction) > NifOp.props.epsilon:
-                NifLog.info(f"Applying scale correction {NifOp.props.scale_correction}")
+            # moved from NifOp.props.scale_correction
+            scale_correction = bpy.context.scene.niftools_scene.scale_correction
+            if abs(scale_correction) > NifOp.props.epsilon:
+                NifLog.info(f"Applying scale correction {scale_correction}")
                 data.roots = [root_block]
                 toaster = pyffi.spells.nif.NifToaster()
-                toaster.scale = 1 / NifOp.props.scale_correction
+                toaster.scale = 1 / scale_correction
                 pyffi.spells.nif.fix.SpellScale(data=data, toaster=toaster).recurse()
 
                 # also scale egm
                 if EGMData.data:
-                    EGMData.data.apply_scale(1 / NifOp.props.scale_correction)
+                    EGMData.data.apply_scale(1 / scale_correction)
 
             # generate mopps (must be done after applying scale!)
             if bpy.context.scene.niftools_scene.game in ('OBLIVION', 'FALLOUT_3', 'SKYRIM'):

--- a/io_scene_niftools/nif_export.py
+++ b/io_scene_niftools/nif_export.py
@@ -44,7 +44,6 @@ import bpy
 import pyffi.spells.nif.fix
 from pyffi.formats.nif import NifFormat
 
-import io_scene_niftools.utils.logging
 from io_scene_niftools.modules.nif_export.animation.transform import TransformAnimation
 from io_scene_niftools.modules.nif_export.collision import Collision
 from io_scene_niftools.modules.nif_export.constraint import Constraint
@@ -116,9 +115,9 @@ class NifExport(NifCommon):
                     if b_obj.parent and b_obj.parent.type == 'ARMATURE':
                         for b_mod in b_obj.modifiers:
                             if b_mod.type == 'ARMATURE' and b_mod.use_bone_envelopes:
-                                raise io_scene_niftools.utils.logging.NifError(f"'{b_obj.name}': Cannot export envelope skinning. If you have vertex groups, turn off envelopes.\n"
-                                                         f"If you don't have vertex groups, select the bones one by one press W to "
-                                                         f"convert their envelopes to vertex weights, and turn off envelopes.")
+                                raise NifError(f"'{b_obj.name}': Cannot export envelope skinning. If you have vertex groups, turn off envelopes.\n"
+                                               f"If you don't have vertex groups, select the bones one by one press W to "
+                                               f"convert their envelopes to vertex weights, and turn off envelopes.")
 
                 # check for non-uniform transforms
                 scale = b_obj.matrix_local.to_scale()
@@ -282,7 +281,6 @@ class NifExport(NifCommon):
             """
 
             # apply scale
-            # moved from NifOp.props.scale_correction
             scale_correction = bpy.context.scene.niftools_scene.scale_correction
             if abs(scale_correction) > NifOp.props.epsilon:
                 NifLog.info(f"Applying scale correction {scale_correction}")

--- a/io_scene_niftools/nif_import.py
+++ b/io_scene_niftools/nif_import.py
@@ -110,6 +110,8 @@ class NifImport(NifCommon):
             # scale tree
             toaster = pyffi.spells.nif.NifToaster()
             toaster.scale = NifOp.props.scale_correction
+            # store scale correction
+            bpy.context.scene.niftools_scene.scale_correction = NifOp.props.scale_correction
             pyffi.spells.nif.fix.SpellScale(data=NifData.data, toaster=toaster).recurse()
 
             # import all root blocks

--- a/io_scene_niftools/nif_import.py
+++ b/io_scene_niftools/nif_import.py
@@ -109,7 +109,7 @@ class NifImport(NifCommon):
 
             # scale tree
             toaster = pyffi.spells.nif.NifToaster()
-            toaster.scale = NifOp.props.scale_correction_import
+            toaster.scale = NifOp.props.scale_correction
             pyffi.spells.nif.fix.SpellScale(data=NifData.data, toaster=toaster).recurse()
 
             # import all root blocks

--- a/io_scene_niftools/operators/common_op.py
+++ b/io_scene_niftools/operators/common_op.py
@@ -84,21 +84,12 @@ class CommonDevOperator:
         options={'HIDDEN'})
 
 
-class CommonImportScale:
+class CommonScale:
     # Number of nif units per blender unit.
-    scale_correction_import: bpy.props.FloatProperty(
-        name="Scale Correction Import",
+    scale_correction: bpy.props.FloatProperty(
+        name="Scale Correction",
         description="Changes size of mesh to fit onto Blender's default grid.",
         default=0.1,
-        min=0.001, max=100.0, precision=2)
-
-
-class CommonExportScale:
-    # Number of blender units per nif unit.
-    scale_correction_export: bpy.props.FloatProperty(
-        name="Scale Correction Export",
-        description="Changes size of mesh from Blender default to nif default.",
-        default=10.0,
         min=0.001, max=100.0, precision=2)
 
 

--- a/io_scene_niftools/operators/common_op.py
+++ b/io_scene_niftools/operators/common_op.py
@@ -103,7 +103,7 @@ class CommonNif:
         options={'HIDDEN'})
 
 
-class CommonEGM:
+class CommonEgm:
     # Default file name extension.
     filename_ext = ".egm"
 
@@ -113,7 +113,7 @@ class CommonEGM:
         options={'HIDDEN'})
 
 
-class CommonKF:
+class CommonKf:
     # Default file name extension.
     filename_ext = ".kf"
 

--- a/io_scene_niftools/operators/common_op.py
+++ b/io_scene_niftools/operators/common_op.py
@@ -36,8 +36,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 # ***** END LICENSE BLOCK *****
-
-
 import bpy
 
 
@@ -85,10 +83,19 @@ class CommonDevOperator:
 
 
 class CommonScale:
+
+    def get_import_scale(self):
+        return bpy.context.scene.niftools_scene.scale_correction
+
+    def set_import_scale(self, scale):
+        bpy.context.scene.niftools_scene.scale_correction = scale
+
     # Number of nif units per blender unit.
     scale_correction: bpy.props.FloatProperty(
         name="Scale Correction",
         description="Changes size of mesh to fit onto Blender's default grid.",
+        get=get_import_scale,
+        set=set_import_scale,
         default=0.1,
         min=0.001, max=100.0, precision=2)
 

--- a/io_scene_niftools/operators/egm_import_op.py
+++ b/io_scene_niftools/operators/egm_import_op.py
@@ -41,10 +41,10 @@ from bpy.types import Operator
 from bpy_extras.io_utils import ImportHelper
 
 from io_scene_niftools import egm_import
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonEGM, CommonScale
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonEgm, CommonScale
 
 
-class EgmImportOperator(Operator, ImportHelper, CommonScale, CommonEGM, CommonDevOperator):
+class EgmImportOperator(Operator, ImportHelper, CommonScale, CommonEgm, CommonDevOperator):
     """Operator for loading a egm file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/operators/egm_import_op.py
+++ b/io_scene_niftools/operators/egm_import_op.py
@@ -41,10 +41,10 @@ from bpy.types import Operator
 from bpy_extras.io_utils import ImportHelper
 
 from io_scene_niftools import egm_import
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonEGM, CommonImportScale
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonEGM, CommonScale
 
 
-class EgmImportOperator(Operator, ImportHelper, CommonImportScale, CommonEGM, CommonDevOperator):
+class EgmImportOperator(Operator, ImportHelper, CommonScale, CommonEGM, CommonDevOperator):
     """Operator for loading a egm file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/operators/kf_export_op.py
+++ b/io_scene_niftools/operators/kf_export_op.py
@@ -43,7 +43,7 @@ from bpy_extras.io_utils import ExportHelper
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.kf_export import KfExport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonKF
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonKf
 
 
 def _game_to_enum(game):
@@ -53,7 +53,7 @@ def _game_to_enum(game):
     return enum
 
 
-class KfExportOperator(Operator, ExportHelper, CommonDevOperator, CommonScale, CommonKF):
+class KfExportOperator(Operator, ExportHelper, CommonDevOperator, CommonScale, CommonKf):
     """Operator for saving a kf file."""
 
     # Name of function for calling the kf export operators.

--- a/io_scene_niftools/operators/kf_export_op.py
+++ b/io_scene_niftools/operators/kf_export_op.py
@@ -43,7 +43,7 @@ from bpy_extras.io_utils import ExportHelper
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.kf_export import KfExport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonExportScale, CommonKF
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonKF
 
 
 def _game_to_enum(game):
@@ -53,7 +53,7 @@ def _game_to_enum(game):
     return enum
 
 
-class KfExportOperator(Operator, ExportHelper, CommonDevOperator, CommonExportScale, CommonKF):
+class KfExportOperator(Operator, ExportHelper, CommonDevOperator, CommonScale, CommonKF):
     """Operator for saving a kf file."""
 
     # Name of function for calling the kf export operators.

--- a/io_scene_niftools/operators/kf_import_op.py
+++ b/io_scene_niftools/operators/kf_import_op.py
@@ -42,10 +42,10 @@ from bpy.types import Operator, PropertyGroup
 from bpy_extras.io_utils import ImportHelper
 
 from io_scene_niftools.kf_import import KfImport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonKF
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonKf
 
 
-class KfImportOperator(Operator, ImportHelper, CommonDevOperator, CommonScale, CommonKF):
+class KfImportOperator(Operator, ImportHelper, CommonDevOperator, CommonScale, CommonKf):
     """Operator for loading a kf file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/operators/kf_import_op.py
+++ b/io_scene_niftools/operators/kf_import_op.py
@@ -42,10 +42,10 @@ from bpy.types import Operator, PropertyGroup
 from bpy_extras.io_utils import ImportHelper
 
 from io_scene_niftools.kf_import import KfImport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonImportScale, CommonKF
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonKF
 
 
-class KfImportOperator(Operator, ImportHelper, CommonDevOperator, CommonImportScale, CommonKF):
+class KfImportOperator(Operator, ImportHelper, CommonDevOperator, CommonScale, CommonKF):
     """Operator for loading a kf file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/operators/nif_export_op.py
+++ b/io_scene_niftools/operators/nif_export_op.py
@@ -43,7 +43,7 @@ from bpy_extras.io_utils import ExportHelper
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.nif_export import NifExport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonNif
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonNIF
 
 
 def _game_to_enum(game):
@@ -53,7 +53,7 @@ def _game_to_enum(game):
     return enum
 
 
-class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonScale, CommonNif):
+class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonScale, CommonNIF):
     """Operator for saving a nif file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/operators/nif_export_op.py
+++ b/io_scene_niftools/operators/nif_export_op.py
@@ -43,7 +43,7 @@ from bpy_extras.io_utils import ExportHelper
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.nif_export import NifExport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonNif
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonNif
 
 
 def _game_to_enum(game):
@@ -53,7 +53,7 @@ def _game_to_enum(game):
     return enum
 
 
-class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonScale, CommonNif):
+class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonNif):
     """Operator for saving a nif file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/operators/nif_export_op.py
+++ b/io_scene_niftools/operators/nif_export_op.py
@@ -43,7 +43,7 @@ from bpy_extras.io_utils import ExportHelper
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.nif_export import NifExport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonExportScale, CommonNif
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonNif
 
 
 def _game_to_enum(game):
@@ -53,7 +53,7 @@ def _game_to_enum(game):
     return enum
 
 
-class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonExportScale, CommonNif):
+class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonScale, CommonNif):
     """Operator for saving a nif file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/operators/nif_export_op.py
+++ b/io_scene_niftools/operators/nif_export_op.py
@@ -43,7 +43,7 @@ from bpy_extras.io_utils import ExportHelper
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.nif_export import NifExport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonNif
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonNif, CommonScale
 
 
 def _game_to_enum(game):
@@ -53,7 +53,7 @@ def _game_to_enum(game):
     return enum
 
 
-class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonNif):
+class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonNif, CommonScale):
     """Operator for saving a nif file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/operators/nif_export_op.py
+++ b/io_scene_niftools/operators/nif_export_op.py
@@ -43,7 +43,7 @@ from bpy_extras.io_utils import ExportHelper
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.nif_export import NifExport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonNIF
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonNif
 
 
 def _game_to_enum(game):
@@ -53,7 +53,7 @@ def _game_to_enum(game):
     return enum
 
 
-class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonScale, CommonNIF):
+class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonScale, CommonNif):
     """Operator for saving a nif file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/operators/nif_import_op.py
+++ b/io_scene_niftools/operators/nif_import_op.py
@@ -42,10 +42,10 @@ from bpy.types import Operator, Panel
 from bpy_extras.io_utils import ImportHelper
 
 from io_scene_niftools.nif_import import NifImport
-from io_scene_niftools.operators.common_op import CommonDevOperator, CommonImportScale, CommonNif
+from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonNif
 
 
-class NifImportOperator(Operator, ImportHelper, CommonImportScale, CommonDevOperator, CommonNif):
+class NifImportOperator(Operator, ImportHelper, CommonScale, CommonDevOperator, CommonNif):
     """Operator for loading a nif file."""
 
     # Name of function for calling the nif export operators.

--- a/io_scene_niftools/properties/scene.py
+++ b/io_scene_niftools/properties/scene.py
@@ -61,7 +61,7 @@ def update_version_from_game(self, context):
     self.user_version_2 = self.USER_VERSION_2.get(self.game, 0)
 
 
-class Scene(PropertyGroup, CommonScale):
+class Scene(PropertyGroup):
 
     nif_version: IntProperty(
         name='Version',
@@ -111,3 +111,9 @@ class Scene(PropertyGroup, CommonScale):
         'FALLOUT_3': 34,
         'SKYRIM': 83
     }
+
+    scale_correction: bpy.props.FloatProperty(
+        name="Scale Correction",
+        description="Changes size of mesh to fit onto Blender's default grid.",
+        default=0.1,
+        min=0.001, max=100.0, precision=2)

--- a/io_scene_niftools/properties/scene.py
+++ b/io_scene_niftools/properties/scene.py
@@ -43,6 +43,8 @@ from bpy.props import PointerProperty, IntProperty
 from bpy.types import PropertyGroup
 from pyffi.formats.nif import NifFormat
 
+from io_scene_niftools.operators.common_op import CommonScale
+
 
 def _game_to_enum(game):
     symbols = ":,'\" +-*!?;./="
@@ -59,7 +61,7 @@ def update_version_from_game(self, context):
     self.user_version_2 = self.USER_VERSION_2.get(self.game, 0)
 
 
-class Scene(PropertyGroup):
+class Scene(PropertyGroup, CommonScale):
 
     nif_version: IntProperty(
         name='Version',

--- a/io_scene_niftools/ui/operator.py
+++ b/io_scene_niftools/ui/operator.py
@@ -91,7 +91,7 @@ class OperatorImportTransformPanel(OperatorSetting, Panel):
         sfile = context.space_data
         operator = sfile.active_operator
 
-        layout.prop(operator, "scale_correction_import")
+        layout.prop(operator, "scale_correction")
 
 
 class OperatorImportArmaturePanel(OperatorSetting, Panel):
@@ -163,7 +163,7 @@ class OperatorExportTransformPanel(OperatorSetting, Panel):
         sfile = context.space_data
         operator = sfile.active_operator
 
-        layout.prop(operator, "scale_correction_export")
+        layout.prop(operator, "scale_correction")
 
 
 class OperatorExportArmaturePanel(OperatorSetting, Panel):

--- a/io_scene_niftools/ui/scene.py
+++ b/io_scene_niftools/ui/scene.py
@@ -88,6 +88,9 @@ class SceneVersionInfoPanel(SceneButtonsPanel, Panel):
         col = flow.column()
         col.prop(nif_scene_props, "user_version_2")
 
+        col = flow.column()
+        col.prop(nif_scene_props, "scale_correction")
+
 
 # class SceneAuthorInfoPanel(SceneButtonsPanel, Panel):
 #     bl_label = "Nif Author Info"

--- a/io_scene_niftools/ui/scene.py
+++ b/io_scene_niftools/ui/scene.py
@@ -88,9 +88,6 @@ class SceneVersionInfoPanel(SceneButtonsPanel, Panel):
         col = flow.column()
         col.prop(nif_scene_props, "user_version_2")
 
-        col = flow.column()
-        col.prop(nif_scene_props, "scale_correction")
-
 
 # class SceneAuthorInfoPanel(SceneButtonsPanel, Panel):
 #     bl_label = "Nif Author Info"


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
as discussed

##  Detailed Description
![image](https://user-images.githubusercontent.com/525919/101225840-79b19500-368a-11eb-90d9-80d67387de23.png)

## Fixes Known Issues
Nif export inheriting from egm common, setting file type to egm

## Documentation
There is only one factor for export and import.
On export, the scripts apply the inverse of what you set for import and export.
Scene stores the factor set on import; export retrieves it from the scene and applies its inverse.

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
