### PR TITLE
Re-enable animation export.

### DIFF
--- a/io_scene_niftools/ui/operator.py
+++ b/io_scene_niftools/ui/operator.py
@@ -38,7 +38,6 @@
 # ***** END LICENSE BLOCK *****
 
 
-import bpy
 from bpy.types import Panel
 
 
@@ -213,6 +212,7 @@ class OperatorExportAnimationPanel(OperatorSetting, Panel):
         sfile = context.space_data
         operator = sfile.active_operator
 
+        layout.prop(operator, "animation")
         layout.prop(operator, "bs_animation_node")
 
 


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
**[Overview of the content of the pull request]**
Fix animation not being registered in the export UI

##  Detailed Description
**[List of functional updates]**
The export ui was missing the reference to the `animation` property of the export operator.

## Fixes Known Issues
**[Ordered list of issues fixed by this PR]**
Partial fix for #410, testing required

## Documentation
**[Overview of updates to documentation]**

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**
Quick manual testing that the dropdown was available

### Manual
**[Set of steps to manually verify updates are working correctly]**
Only tested that the UI was correct, further testing at the feature level required.

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
