### PR TITLE
Added Kf export support for Skyrim

### DIFF
--- a/io_scene_niftools/modules/nif_export/animation/transform.py
+++ b/io_scene_niftools/modules/nif_export/animation/transform.py
@@ -47,7 +47,7 @@ from io_scene_niftools.modules.nif_export.animation import Animation
 from io_scene_niftools.modules.nif_export.block_registry import block_store
 from io_scene_niftools.utils import math
 from io_scene_niftools.utils.singleton import NifOp
-from io_scene_niftools.utils.logging import NifLog
+from io_scene_niftools.utils.logging import NifError, NifLog
 
 
 class TransformAnimation(Animation):
@@ -97,25 +97,30 @@ class TransformAnimation(Animation):
         # skyrim
         elif bpy.context.scene.niftools_scene.game in ('SKYRIM'):
 
-            NifLog.info(f"SKYRIM: Exporting animation on the skeleton: {b_armature.name}")
-            b_action = self.get_active_action(b_armature)
-            kf_root = block_store.create_block("NiControllerSequence")
-            targetname = "Scene Root"
-            for bone in b_armature.data.bones:
-                self.export_transforms(kf_root,b_armature,b_action,bone)
-            anim_textextra = self.export_text_keys(b_action)
+            if b_armature:
+                NifLog.info(f"Skyrim: Exporting animation on the skeleton: {b_armature.name}")
+                b_action = self.get_active_action(b_armature)
+                kf_root = block_store.create_block("NiControllerSequence")
+                targetname = "Scene Root"
+                for bone in b_armature.data.bones:
+                    self.export_transforms(kf_root,b_armature,b_action,bone)
 
-            kf_root.name = b_action.name
-            kf_root.unknown_int_1 = 1
-            kf_root.weight = 1.0
-            kf_root.text_keys = anim_textextra
-            kf_root.cycle_type = NifFormat.CycleType.CYCLE_CLAMP
-            kf_root.frequency = 1.0
-            kf_root.start_time = bpy.context.scene.frame_start * bpy.context.scene.render.fps
-            kf_root.stop_time = (bpy.context.scene.frame_end - bpy.context.scene.frame_start) * bpy.context.scene.render.fps
+                anim_textextra = self.export_text_keys(b_action)
 
-            kf_root.target_name = targetname
-            kf_root.string_palette = NifFormat.NiStringPalette()
+                kf_root.name = b_action.name
+                kf_root.unknown_int_1 = 1
+                kf_root.weight = 1.0
+                kf_root.text_keys = anim_textextra
+                kf_root.cycle_type = NifFormat.CycleType.CYCLE_CLAMP
+                kf_root.frequency = 1.0
+                kf_root.start_time = bpy.context.scene.frame_start * bpy.context.scene.render.fps
+                kf_root.stop_time = (bpy.context.scene.frame_end - bpy.context.scene.frame_start) * bpy.context.scene.render.fps
+
+                kf_root.target_name = targetname
+                kf_root.string_palette = NifFormat.NiStringPalette()
+
+            else:
+                NifError("Cannot export animation without skeleton")
 
         # oblivion
         elif bpy.context.scene.niftools_scene.game in ('OBLIVION', 'FALLOUT_3', 'CIVILIZATION_IV', 'ZOO_TYCOON_2', 'FREEDOM_FORCE_VS_THE_3RD_REICH'):

--- a/io_scene_niftools/modules/nif_export/animation/transform.py
+++ b/io_scene_niftools/modules/nif_export/animation/transform.py
@@ -94,6 +94,29 @@ class TransformAnimation(Animation):
             #         # wipe controller target
             #         ctrl.target = None
 
+        # skyrim
+        elif bpy.context.scene.niftools_scene.game in ('SKYRIM'):
+
+            NifLog.info(f"SKYRIM: Exporting animation on the skeleton: {b_armature.name}")
+            b_action = self.get_active_action(b_armature)
+            kf_root = block_store.create_block("NiControllerSequence")
+            targetname = "Scene Root"
+            for bone in b_armature.data.bones:
+                self.export_transforms(kf_root,b_armature,b_action,bone)
+            anim_textextra = self.export_text_keys(b_action)
+
+            kf_root.name = b_action.name
+            kf_root.unknown_int_1 = 1
+            kf_root.weight = 1.0
+            kf_root.text_keys = anim_textextra
+            kf_root.cycle_type = NifFormat.CycleType.CYCLE_CLAMP
+            kf_root.frequency = 1.0
+            kf_root.start_time = bpy.context.scene.frame_start * bpy.context.scene.render.fps
+            kf_root.stop_time = (bpy.context.scene.frame_end - bpy.context.scene.frame_start) * bpy.context.scene.render.fps
+
+            kf_root.target_name = targetname
+            kf_root.string_palette = NifFormat.NiStringPalette()
+
         # oblivion
         elif bpy.context.scene.niftools_scene.game in ('OBLIVION', 'FALLOUT_3', 'CIVILIZATION_IV', 'ZOO_TYCOON_2', 'FREEDOM_FORCE_VS_THE_3RD_REICH'):
             # TODO [animation] allow for object kf only
@@ -169,7 +192,7 @@ class TransformAnimation(Animation):
             # if variable_2:
             # controlledblock.set_variable_2(variable_2)
         else:
-            raise io_scene_niftools.utils.logging.NifError(f"Keyframe export for '{bpy.context.scene.niftools_scene.game}' is not supported.\nOnly Morrowind, Oblivion, Fallout 3, Civilization IV,"
+            raise io_scene_niftools.utils.logging.NifError(f"Keyframe export for '{bpy.context.scene.niftools_scene.game}' is not supported.\nOnly Morrowind, Oblivion, Skyrim, Fallout 3, Civilization IV,"
                                      " Zoo Tycoon 2, Freedom Force, and Freedom Force vs. the 3rd Reich keyframes are supported.")
         return kf_root
 

--- a/io_scene_niftools/nif_export.py
+++ b/io_scene_niftools/nif_export.py
@@ -161,6 +161,14 @@ class NifExport(NifCommon):
                 kffile = os.path.join(directory, prefix + filebase + ext)
                 data.roots = [kf_root]
                 data.neosteam = (bpy.context.scene.niftools_scene.game == 'NEOSTEAM')
+
+                # scale correction for the skeleton
+                if bpy.context.scene.niftools_scene.game in ('SKYRIM'):
+                    toaster = pyffi.spells.nif.NifToaster()
+                    toaster.scale = round(1 / NifOp.props.scale_correction)
+                    pyffi.spells.nif.fix.SpellScale(data=data, toaster=toaster).recurse()
+                    NifLog.info(f"Scale Correction set to {round(1 / NifOp.props.scale_correction)}")
+
                 with open(kffile, "wb") as stream:
                     data.write(stream)
                 # if only anim, no need to do the time consuming nif export

--- a/io_scene_niftools/ui/operator.py
+++ b/io_scene_niftools/ui/operator.py
@@ -212,7 +212,7 @@ class OperatorExportAnimationPanel(OperatorSetting, Panel):
 
         sfile = context.space_data
         operator = sfile.active_operator
-
+        layout.prop(operator, "animation")
         layout.prop(operator, "bs_animation_node")
 
 


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
Now the plugin can export kf animation for Skyrim.

##  Detailed Description
Kf export was only supported for two other games, now I have added support for skyrim too. The kf file exported has the correct version number and correct block structure for Skyrim.

## Fixes Known Issues
I have also fixed the animation option not showing up in the export panel.

## Documentation
To export a kf file, select "animation only" option.

## Testing
I have exported animations from Blender and tested them in Nifskope. Everything appears good in there.

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
