### PR TITLE
Minor animation export bugs fixed

### DIFF
--- a/io_scene_niftools/modules/nif_export/animation/transform.py
+++ b/io_scene_niftools/modules/nif_export/animation/transform.py
@@ -100,7 +100,7 @@ class TransformAnimation(Animation):
                 NifLog.info(f"Skyrim: Exporting animation on the skeleton: {b_armature.name}")
                 b_action = self.get_active_action(b_armature)
                 kf_root = block_store.create_block("NiControllerSequence")
-                targetname = "Scene Root"
+                targetname = "NPC Root [Root]"
                 for bone in b_armature.data.bones:
                     self.export_transforms(kf_root,b_armature,b_action,bone)
 
@@ -112,11 +112,16 @@ class TransformAnimation(Animation):
                 kf_root.text_keys = anim_textextra
                 kf_root.cycle_type = NifFormat.CycleType.CYCLE_CLAMP
                 kf_root.frequency = 1.0
-                kf_root.start_time = bpy.context.scene.frame_start * bpy.context.scene.render.fps
-                kf_root.stop_time = (bpy.context.scene.frame_end - bpy.context.scene.frame_start) * bpy.context.scene.render.fps
 
                 kf_root.target_name = targetname
                 kf_root.string_palette = NifFormat.NiStringPalette()
+
+                if anim_textextra.num_text_keys > 0:
+                    kf_root.start_time = anim_textextra.text_keys[0].time
+                    kf_root.stop_time = anim_textextra.text_keys[anim_textextra.num_text_keys - 1].time
+                else:
+                    kf_root.start_time = bpy.context.scene.frame_start * bpy.context.scene.render.fps
+                    kf_root.stop_time = (bpy.context.scene.frame_end - bpy.context.scene.frame_start) * bpy.context.scene.render.fps
 
             else:
                 NifError("Cannot export animation without skeleton")


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
Fixed two minor bugs with kf export

##  Detailed Description

- Fixed the bug where the animation start and stop times were very high
- Fixed the target name of the NiControllerSequence. Changed the target name from Scene root to NPC Root [Root]. Here the target name should be the name of the root bone of the skeleton.

## Fixes Known Issues
#420 

## Documentation
**[Overview of updates to documentation]**

## Testing
Tested the exported files using NifSkope. All the values are correct.

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
