### PR TITLE
Updated shader import/export, mostly for BSShaderProperty.

### DIFF
--- a/io_scene_nif/modules/nif_export/property/texture/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/texture/__init__.py
@@ -115,9 +115,12 @@ class TextureSlotManager:
         for b_texture_node in self.get_used_textslots(b_mat):
             NifLog.debug(f"Found node {b_texture_node.name} of type {b_texture_node.label}")
 
+            shown_label = b_texture_node.label
+            if shown_label == '':
+                shown_label = b_texture_node.image.name
             # go over all slots
             for slot_name in self.slots.keys():
-                if slot_name in b_texture_node.label:
+                if slot_name in shown_label:
                     # slot has already been populated
                     if self.slots[slot_name]:
                         raise util_math.NifError(f"Multiple {slot_name} textures in material '{b_mat.name}''.\n"
@@ -127,5 +130,5 @@ class TextureSlotManager:
                     break
             # unsupported texture type
             else:
-                raise util_math.NifError(f"Do not know how to export texture node '{b_texture_node.name}' in material '{b_mat.name}'."
+                raise util_math.NifError(f"Do not know how to export texture node '{b_texture_node.name}' in material '{b_mat.name}' with label '{shown_label}'."
                                          f"Delete it or change its label.")

--- a/io_scene_nif/modules/nif_export/property/texture/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/texture/__init__.py
@@ -71,13 +71,37 @@ class TextureSlotManager:
                 "Specular": None,
                 "Normal": None,
         }
+    
+    def get_input_node_of_type(self, input_socket, node_types):
+        #search back in the node tree for nodes of a certain type(s), depth-first
+        links = input_socket.links
+        if not links:
+            #this socket has no inputs
+            return None
+        node = links[0].from_node
+        if isinstance(node, node_types):
+            #the input node is of the required type
+            return node
+        else:
+            if len(node.inputs) > 0:
+                for input in node.inputs:
+                    #check every input if somewhere up that tree is a node of the required type
+                    input_results = self.get_input_node_of_type(input, node_types)
+                    if input_results:
+                        return input_results
+                #we found nothing
+                return None
+            else:
+                #this has no inputs, and doesn't classify itself
+                return None
 
     def get_uv_node(self, b_texture_node):
-        # check if a node is plugged into the b_texture_node's vector input
-        links = b_texture_node.inputs[0].links
-        if not links:
-            return 0
-        uv_node = links[0].from_node
+        uv_node = self.get_input_node_of_type(b_texture_node.inputs[0], (bpy.types.ShaderNodeUVMap, bpy.types.ShaderNodeTexCoord))
+        if uv_node is None:
+            links = b_texture_node.inputs[0].links
+            if not links:
+                #nothing is plugged in, so it will use the first UV map
+                return 0
         if isinstance(uv_node, bpy.types.ShaderNodeUVMap):
             uv_name = uv_node.uv_map
             try:
@@ -90,6 +114,33 @@ class TextureSlotManager:
         else:
             raise util_math.NifError(f"Unsupported vector input for {b_texture_node.name} in material '{self.b_mat.name}''.\n"
                                      f"Expected 'UV Map' or 'Texture Coordinate' nodes")
+
+    def get_global_uv_transform_clip(self, b_texture_node):
+        #get the values from the nodes, find the nodes by name, or search back in the node tree
+        x_scale = y_scale = x_offset = y_offset = clamp_x = clamp_y = None
+        #first check if there are any of the preset name - much more time efficient
+        try:
+            combine_node = b_texture_node.id_data.nodes["Combine UV0"]
+            if not isinstance(combine_node, bpy.types.ShaderNodeCombineXYZ):
+                combine_node = self.get_input_node_of_type(b_texture_node.inputs[0], bpy.types.ShaderNodeCombineXYZ)
+        except:
+            #if there is a combine node, it does not have the standard name
+            combine_node = self.get_input_node_of_type(b_texture_node.inputs[0], bpy.types.ShaderNodeCombineXYZ)
+            
+        if combine_node:
+            x_link = combine_node.inputs[0].links
+            if x_link:
+                x_node = x_link[0].from_node
+                x_scale =  x_node.inputs[1].default_value
+                x_offset =  x_node.inputs[2].default_value
+                clamp_x = x_node.use_clamp
+            y_link = combine_node.inputs[1].links
+            if y_link:
+                y_node = y_link[0].from_node
+                y_scale = y_node.inputs[1].default_value
+                y_offset = y_node.inputs[2].default_value
+                clamp_y = y_node.use_clamp
+        return x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y
 
     @staticmethod
     def get_used_textslots(b_mat):

--- a/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -80,9 +80,14 @@ class NodesWrapper:
             self.tree.links.new(uv.outputs[6], b_texture_node.inputs[0])
         # use supplied UV maps for everything else, if present
         else:
-            uv = self.tree.nodes.new('ShaderNodeUVMap')
-            uv.name = "TexCoordIndex" + str(uv_index)
-            uv.uv_map = f"UV{uv_index}"
+            uv_name = "TexCoordIndex" + str(uv_index)
+            existing_node = self.tree.nodes.get(uv_name)
+            if not existing_node:
+                uv = self.tree.nodes.new('ShaderNodeUVMap')
+                uv.name = uv_name
+                uv.uv_map = f"UV{uv_index}"
+            else:
+                uv = existing_node
             self.tree.links.new(uv.outputs[0], b_texture_node.inputs[0])
             # todo [texture/anim] if present in nifs, support it and move to anim sys
             # if tex_transform or tex_anim:

--- a/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -108,6 +108,63 @@ class NodesWrapper:
             #                 transform.keyframe_insert("translation", index=j, frame=int(key[0] * fps))
             #     tree.links.new(uv.outputs[0], transform.inputs[0])
             #     tree.links.new(transform.outputs[0], tex.inputs[0])
+        
+    def global_uv_offset_scale(self, x_offset, y_offset, x_scale, y_scale, clamp_x, clamp_y):
+        # get all uv nodes (by name, since we are importing they have the predefined name
+        # and then we don't have to loop through every node
+        uv_nodes = {}
+        i = 0
+        while True:
+            uv_name = "TexCoordIndex" + str(i)
+            i +=1
+            uv_node = self.tree.nodes.get(uv_name)
+            if uv_node and isinstance(uv_node, bpy.types.ShaderNodeUVMap):
+                uv_nodes[uv_name] = uv_node
+            else:
+                break
+        
+        b_x_offset = 1 - x_offset - x_scale
+        b_y_offset = 1 - y_offset - y_scale
+        b_x_scale = x_scale
+        b_y_scale = y_scale
+        clip_texture = clamp_x and clamp_y
+
+        for uv_name, uv_node in uv_nodes.items():
+            #for each of those, create a new uv output node and relink
+            split_node = self.tree.nodes.new("ShaderNodeSeparateXYZ")
+            combine_node = self.tree.nodes.new("ShaderNodeCombineXYZ")
+            
+            x_node = self.tree.nodes.new("ShaderNodeMath")
+            x_node.operation = 'MULTIPLY_ADD'
+            x_node.use_clamp = clamp_x and not clip_texture
+            x_node.inputs[1].default_value = b_x_scale
+            x_node.inputs[2].default_value = b_x_offset
+            self.tree.links.new(split_node.outputs[0], x_node.inputs[0])
+            self.tree.links.new(x_node.outputs[0], combine_node.inputs[0])
+            
+            y_node = self.tree.nodes.new("ShaderNodeMath")
+            y_node.operation = 'MULTIPLY_ADD'
+            y_node.use_clamp = clamp_y and not clip_texture
+            y_node.inputs[1].default_value = b_y_scale
+            y_node.inputs[2].default_value = b_y_offset
+            self.tree.links.new(split_node.outputs[1], y_node.inputs[0])
+            self.tree.links.new(y_node.outputs[0], combine_node.inputs[1])
+        
+            #get all the texture nodes to which it is linked, and re-link them to the uv output node
+            for link in uv_node.outputs[0].links:
+                #get the target link/socket
+                target_node = link.to_node
+                if isinstance(link.to_node, bpy.types.ShaderNodeTexImage):
+                    target_socket = link.to_socket
+                    #delete the existing link
+                    self.tree.links.remove(link)
+                    #make new ones
+                    self.tree.links.new(combine_node.outputs[0], target_socket)
+                    #if we clamp in both directions, clip the images:
+                    if clip_texture:
+                        target_node.extension = 'CLIP'
+            self.tree.links.new(uv_node.outputs[0],split_node.inputs[0])
+        pass
 
     def clear_default_nodes(self):
         self.b_mat.use_backface_culling = True

--- a/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -109,44 +109,51 @@ class NodesWrapper:
             #     tree.links.new(uv.outputs[0], transform.inputs[0])
             #     tree.links.new(transform.outputs[0], tex.inputs[0])
         
-    def global_uv_offset_scale(self, x_offset, y_offset, x_scale, y_scale, clamp_x, clamp_y):
+    def global_uv_offset_scale(self, x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y):
         # get all uv nodes (by name, since we are importing they have the predefined name
         # and then we don't have to loop through every node
         uv_nodes = {}
         i = 0
         while True:
             uv_name = "TexCoordIndex" + str(i)
-            i +=1
             uv_node = self.tree.nodes.get(uv_name)
             if uv_node and isinstance(uv_node, bpy.types.ShaderNodeUVMap):
                 uv_nodes[uv_name] = uv_node
+                i +=1
             else:
                 break
         
-        b_x_offset = 1 - x_offset - x_scale
-        b_y_offset = 1 - y_offset - y_scale
-        b_x_scale = x_scale
-        b_y_scale = y_scale
+
         clip_texture = clamp_x and clamp_y
 
         for uv_name, uv_node in uv_nodes.items():
             #for each of those, create a new uv output node and relink
             split_node = self.tree.nodes.new("ShaderNodeSeparateXYZ")
+            split_node.name = "Separate UV" + uv_name[-1]
+            split_node.label = split_node.name
             combine_node = self.tree.nodes.new("ShaderNodeCombineXYZ")
+            combine_node.name = "Combine UV" + uv_name[-1]
+            combine_node.label = combine_node.name
             
             x_node = self.tree.nodes.new("ShaderNodeMath")
+            x_node.name = "X offset and scale UV" + uv_name[-1]
+            x_node.label = x_node.name
             x_node.operation = 'MULTIPLY_ADD'
+            #only clamp on the math node when we're not clamping on both directions
+            #otherwise, the clip on the image texture node will take care of it
             x_node.use_clamp = clamp_x and not clip_texture
-            x_node.inputs[1].default_value = b_x_scale
-            x_node.inputs[2].default_value = b_x_offset
+            x_node.inputs[1].default_value = x_scale
+            x_node.inputs[2].default_value = x_offset
             self.tree.links.new(split_node.outputs[0], x_node.inputs[0])
             self.tree.links.new(x_node.outputs[0], combine_node.inputs[0])
             
             y_node = self.tree.nodes.new("ShaderNodeMath")
+            y_node.name = "Y offset and scale UV" + uv_name[-1]
+            y_node.label = y_node.name
             y_node.operation = 'MULTIPLY_ADD'
             y_node.use_clamp = clamp_y and not clip_texture
-            y_node.inputs[1].default_value = b_y_scale
-            y_node.inputs[2].default_value = b_y_offset
+            y_node.inputs[1].default_value = y_scale
+            y_node.inputs[2].default_value = y_offset
             self.tree.links.new(split_node.outputs[1], y_node.inputs[0])
             self.tree.links.new(y_node.outputs[0], combine_node.inputs[1])
         

--- a/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -237,6 +237,13 @@ class NodesWrapper:
 
     def link_normal_node(self, b_texture_node):
         b_texture_node.label = "Normal"
+        #set to non-color data
+        b_texture_node.image.colorspace_settings.name = 'Non-Color'
+        #create tangent normal map converter and link to it
+        tangent_converter = self.b_mat.node_tree.nodes.new("ShaderNodeNormalMap")
+        self.tree.links.new(b_texture_node.outputs[0], tangent_converter.inputs[1])
+        #link to the diffuse shader
+        self.tree.links.new(tangent_converter.outputs[0], self.diffuse_shader.inputs[2])
         # # Influence mapping
         # b_texture_node.texture.use_normal_map = True  # causes artifacts otherwise.
         #

--- a/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
+++ b/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
@@ -117,15 +117,42 @@ class BSShaderPropertyProcessor(BSShader):
         # Textures
         self.texturehelper.import_bsshaderproperty_textureset(bs_shader_property, self._nodes_wrapper)
 
-        # TODO [shader] UV offset node support
-        # if hasattr(bs_shader_property, 'texture_clamp_mode'):
-        #     self.import_clamp(self.b_mat, bs_shader_property)
-        #
-        # if hasattr(bs_shader_property, 'uv_offset'):
-        #     self.import_uv_offset(self.b_mat, bs_shader_property)
-        #
-        # if hasattr(bs_shader_property, 'uv_scale'):
-        #     self.import_uv_scale(self.b_mat, bs_shader_property)
+        #translate the clamp, uv offset and uv scale to values to use in blender
+        if hasattr(bs_shader_property, 'texture_clamp_mode'):
+            clamp_mode = bs_shader_property.texture_clamp_mode
+            if clamp_mode == 3:
+                clamp_x = False
+                clamp_y = False
+            if clamp_mode == 2:
+                clamp_x = False
+                clamp_y = True
+            if clamp_mode == 1:
+                clamp_x = True
+                clamp_y = False
+            if clamp_mode == 0:
+                clamp_x = True
+                clamp_y = True
+        else:
+            clamp_x = False
+            clamp_y = False
+
+        if hasattr(bs_shader_property, 'uv_offset'):
+            x_offset = bs_shader_property.uv_offset.u
+            y_offset = bs_shader_property.uv_offset.v
+        else:
+            x_offset = 0
+            y_offset = 0
+        
+        if hasattr(bs_shader_property, 'uv_scale'):
+            x_scale = bs_shader_property.uv_scale.u
+            y_scale = bs_shader_property.uv_scale.v
+        else:
+            x_scale = 1
+            y_scale = 1
+
+        b_x_offset = 1 - x_offset - x_scale
+        b_y_offset = 1 - y_offset - y_scale
+        self._nodes_wrapper.global_uv_offset_scale(b_x_offset, b_y_offset, x_scale, y_scale, clamp_x, clamp_y)
 
         # Diffuse color
         if bs_shader_property.skin_tint_color:

--- a/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
+++ b/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
@@ -120,16 +120,16 @@ class BSShaderPropertyProcessor(BSShader):
         #translate the clamp, uv offset and uv scale to values to use in blender
         if hasattr(bs_shader_property, 'texture_clamp_mode'):
             clamp_mode = bs_shader_property.texture_clamp_mode
-            if clamp_mode == 3:
+            if clamp_mode == NifFormat.TexClampMode.WRAP_S_WRAP_T:
                 clamp_x = False
                 clamp_y = False
-            if clamp_mode == 2:
+            if clamp_mode == NifFormat.TexClampMode.WRAP_S_CLAMP_T:
                 clamp_x = False
                 clamp_y = True
-            if clamp_mode == 1:
+            if clamp_mode == NifFormat.TexClampMode.CLAMP_S_WRAP_T:
                 clamp_x = True
                 clamp_y = False
-            if clamp_mode == 0:
+            if clamp_mode == NifFormat.TexClampMode.CLAMP_S_CLAMP_T:
                 clamp_x = True
                 clamp_y = True
         else:
@@ -150,9 +150,9 @@ class BSShaderPropertyProcessor(BSShader):
             x_scale = 1
             y_scale = 1
 
-        b_x_offset = 1 - x_offset - x_scale
+        #only the y offset needs conversion, xoffset is the same for the same result
         b_y_offset = 1 - y_offset - y_scale
-        self._nodes_wrapper.global_uv_offset_scale(b_x_offset, b_y_offset, x_scale, y_scale, clamp_x, clamp_y)
+        self._nodes_wrapper.global_uv_offset_scale(x_scale, y_scale, x_offset, b_y_offset, clamp_x, clamp_y)
 
         # Diffuse color
         if bs_shader_property.skin_tint_color:


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
- Normal map images are now linked correctly to the BSDF node. 
- Image texture nodes without a label, now also looks at the name of the image.
- Import and export of UV scale, UV offset and texture clamp mode for BSShaderProperty, via shader nodes.

##  Detailed Description
- Normal map image texture nodes are now set to non-color data, and linked through the normal map node (needed to convert the normal map texture to proper normal information).
- Image texture nodes without a label, now also looks at the name of the image. This is more of a quality of life feature. Previously an unlabeled node led to an error, even though it looked like the node was labelled correctly, because the image name displays as the label when it is not set.
- Import of UV scale, UV offset and texture clamp mode happens by splitting the UV Map node output into X and Y (U and V), then using math nodes (which multiply and add) separately. The splitting (instead of Vector Math nodes) happens so that there can be a separate clamp per dimension (X and Y). In principle this could also happen with four separate vector math nodes (multiple, add and minimum/maximum). There is a difference between Blender and nif: when it clips in only one direction, it takes the value of the edge pixels, rather than going to 0.
- Export of UV scale, UV offset and texture clamp mode does the reverse of the import. However, if the nodes have different names than the import gave them or they don't exist, it either traces back through the UV input of the base image texture, or assumes default values, respectively.

## Fixes Known Issues
1. Related to #81 ? (but only for BSShaderProperty)

## Documentation
**[Overview of updates to documentation]**

## Testing
- Import a nif with non-standard UV scale, offset and wrap, See that it produces the same result in Blender, and that the values are again the same when exporting that.

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
BSEffectShaderProperty has similar fields. May change so that it works for that, too in the future. Should not be too difficult, as most of the values are the same, though the texture clamp mode is byte instead of TexClampMode.
