### PR TITLE
Updated shader import/export, mostly for BSShaderProperty

### DIFF
--- a/docs/user/features/properties/shader/index.rst
+++ b/docs/user/features/properties/shader/index.rst
@@ -99,6 +99,7 @@ Skyrim PP shader for assigning material/shader/texture.
 
 This shader node is used for things.
 
+<<<<<<< HEAD
 +-------------------------------+----------------------------------------------------------------+
 |           Property            |                          Description                           |
 +===============================+================================================================+
@@ -229,6 +230,15 @@ This shader node is used for things.
 +-------------------------------+----------------------------------------------------------------+
 | Z-Buffer Write                | Enables writing to the z-buffer                                |
 +-------------------------------+----------------------------------------------------------------+
+
+When importing a BS Lighting Shader Property, the UV scale, UV offset and the clamp mode are converted into shader 
+nodes. When this happens, the UV Map input node is first split into X and Y, and later combined for a final output. 
+This combining node is what the exporter looks for when trying to find the nodes that do the X and Y transform. 
+Therefore, it has a standard name: *'Combine UV0'*. The label is also the same by default, but that can be anything. 
+If you want to export UV Scale, UV Offset or the clamp mode, making sure it follows this format is the best way to do 
+it. If there is no node with that name, the exporter will still try to find that node by tracing back from the UV map 
+input of the 'Base' image texture node, but it will give you a warning. If none are found, the standard values are 
+chosen.
 
 .. _shader-effect:
 

--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -350,6 +350,8 @@ class Mesh:
             # (civ4 seems to be consistent with not using tangent space on non shadered nifs)
             if mesh_uv_layers and mesh_hasnormals:
                 if bpy.context.scene.niftools_scene.game in ('OBLIVION', 'FALLOUT_3', 'SKYRIM') or (bpy.context.scene.niftools_scene.game in self.texture_helper.USED_EXTRA_SHADER_TEXTURES):
+                    if bpy.context.scene.niftools_scene.game == 'SKYRIM':
+                        tridata.bs_num_uv_sets = tridata.bs_num_uv_sets + 4096
                     trishape.update_tangent_space(as_extra=(bpy.context.scene.niftools_scene.game == 'OBLIVION'))
 
             # todo [mesh/object] use more sophisticated armature finding, also taking armature modifier into account

--- a/io_scene_niftools/modules/nif_export/property/texture/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/__init__.py
@@ -115,9 +115,12 @@ class TextureSlotManager:
         for b_texture_node in self.get_used_textslots(b_mat):
             NifLog.debug(f"Found node {b_texture_node.name} of type {b_texture_node.label}")
 
+            shown_label = b_texture_node.label
+            if shown_label == '':
+                shown_label = b_texture_node.image.name
             # go over all slots
             for slot_name in self.slots.keys():
-                if slot_name in b_texture_node.label:
+                if slot_name in shown_label:
                     # slot has already been populated
                     if self.slots[slot_name]:
                         raise NifError(f"Multiple {slot_name} textures in material '{b_mat.name}''.\n"
@@ -127,5 +130,5 @@ class TextureSlotManager:
                     break
             # unsupported texture type
             else:
-                raise NifError(f"Do not know how to export texture node '{b_texture_node.name}' in material '{b_mat.name}'."
-                               f"Delete it or change its label.")
+                raise NifError(f"Do not know how to export texture node '{b_texture_node.name}' in material '{b_mat.name}' with label '{shown_label}'."
+                                         f"Delete it or change its label.")

--- a/io_scene_niftools/modules/nif_export/property/texture/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/__init__.py
@@ -123,9 +123,13 @@ class TextureSlotManager:
             combine_node = b_texture_node.id_data.nodes["Combine UV0"]
             if not isinstance(combine_node, bpy.types.ShaderNodeCombineXYZ):
                 combine_node = self.get_input_node_of_type(b_texture_node.inputs[0], bpy.types.ShaderNodeCombineXYZ)
+                NifLog.warn(f"Found node with name 'Combine UV0', but it was of the wrong type.\n"
+                            f"Searching through vector input of base texture gave {combine_node}")
         except:
             #if there is a combine node, it does not have the standard name
             combine_node = self.get_input_node_of_type(b_texture_node.inputs[0], bpy.types.ShaderNodeCombineXYZ)
+            NifLog.warn(f"Did not find node with 'Combine UV0' name.\n"
+                        f"Searching through vector input of base texture gave {combine_node}")
             
         if combine_node:
             x_link = combine_node.inputs[0].links
@@ -164,11 +168,11 @@ class TextureSlotManager:
         self._reset_fields()
 
         for b_texture_node in self.get_used_textslots(b_mat):
-            NifLog.debug(f"Found node {b_texture_node.name} of type {b_texture_node.label}")
-
             shown_label = b_texture_node.label
             if shown_label == '':
                 shown_label = b_texture_node.image.name
+            NifLog.debug(f"Found node {b_texture_node.name} of type {shown_label}")
+
             # go over all slots
             for slot_name in self.slots.keys():
                 if slot_name in shown_label:

--- a/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -88,16 +88,21 @@ class BSShaderTexture(TextureSlotManager):
         #get the offset, scale and UV wrapping mode and set them
         x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_global_uv_transform_clip(self.slots["Base"])
         #default values for if they haven't been defined:
-        if x_scale is None: x_scale = 1
-        if y_scale is None: y_scale = 1
-        if x_offset is None: x_offset = 0
+        if x_scale is None:
+            x_scale = 1
+        if y_scale is None:
+            y_scale = 1
+        if x_offset is None:
+            x_offset = 0
         if y_offset is None:
             y_offset = 0
         else:
-        #need to translate blender offset to nif offset to get the same results
+            #need to translate blender offset to nif offset to get the same results
             y_offset = 1 - y_scale - y_offset
-        if clamp_x is None: clamp_x = False
-        if clamp_y is None: clamp_y = False
+        if clamp_x is None:
+            clamp_x = False
+        if clamp_y is None:
+            clamp_y = False
 
         if hasattr(bsshader, "uv_scale"):
             bsshader.uv_scale.u = x_scale

--- a/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -236,6 +236,13 @@ class NodesWrapper:
 
     def link_normal_node(self, b_texture_node):
         b_texture_node.label = "Normal"
+        #set to non-color data
+        b_texture_node.image.colorspace_settings.name = 'Non-Color'
+        #create tangent normal map converter and link to it
+        tangent_converter = self.b_mat.node_tree.nodes.new("ShaderNodeNormalMap")
+        self.tree.links.new(b_texture_node.outputs[0], tangent_converter.inputs[1])
+        #link to the diffuse shader
+        self.tree.links.new(tangent_converter.outputs[0], self.diffuse_shader.inputs[2])
         # # Influence mapping
         # b_texture_node.texture.use_normal_map = True  # causes artifacts otherwise.
         #

--- a/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -108,44 +108,51 @@ class NodesWrapper:
             #     tree.links.new(uv.outputs[0], transform.inputs[0])
             #     tree.links.new(transform.outputs[0], tex.inputs[0])
         
-    def global_uv_offset_scale(self, x_offset, y_offset, x_scale, y_scale, clamp_x, clamp_y):
+    def global_uv_offset_scale(self, x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y):
         # get all uv nodes (by name, since we are importing they have the predefined name
         # and then we don't have to loop through every node
         uv_nodes = {}
         i = 0
         while True:
             uv_name = "TexCoordIndex" + str(i)
-            i +=1
             uv_node = self.tree.nodes.get(uv_name)
             if uv_node and isinstance(uv_node, bpy.types.ShaderNodeUVMap):
                 uv_nodes[uv_name] = uv_node
+                i +=1
             else:
                 break
         
-        b_x_offset = 1 - x_offset - x_scale
-        b_y_offset = 1 - y_offset - y_scale
-        b_x_scale = x_scale
-        b_y_scale = y_scale
+
         clip_texture = clamp_x and clamp_y
 
         for uv_name, uv_node in uv_nodes.items():
             #for each of those, create a new uv output node and relink
             split_node = self.tree.nodes.new("ShaderNodeSeparateXYZ")
+            split_node.name = "Separate UV" + uv_name[-1]
+            split_node.label = split_node.name
             combine_node = self.tree.nodes.new("ShaderNodeCombineXYZ")
+            combine_node.name = "Combine UV" + uv_name[-1]
+            combine_node.label = combine_node.name
             
             x_node = self.tree.nodes.new("ShaderNodeMath")
+            x_node.name = "X offset and scale UV" + uv_name[-1]
+            x_node.label = x_node.name
             x_node.operation = 'MULTIPLY_ADD'
+            #only clamp on the math node when we're not clamping on both directions
+            #otherwise, the clip on the image texture node will take care of it
             x_node.use_clamp = clamp_x and not clip_texture
-            x_node.inputs[1].default_value = b_x_scale
-            x_node.inputs[2].default_value = b_x_offset
+            x_node.inputs[1].default_value = x_scale
+            x_node.inputs[2].default_value = x_offset
             self.tree.links.new(split_node.outputs[0], x_node.inputs[0])
             self.tree.links.new(x_node.outputs[0], combine_node.inputs[0])
             
             y_node = self.tree.nodes.new("ShaderNodeMath")
+            y_node.name = "Y offset and scale UV" + uv_name[-1]
+            y_node.label = y_node.name
             y_node.operation = 'MULTIPLY_ADD'
             y_node.use_clamp = clamp_y and not clip_texture
-            y_node.inputs[1].default_value = b_y_scale
-            y_node.inputs[2].default_value = b_y_offset
+            y_node.inputs[1].default_value = y_scale
+            y_node.inputs[2].default_value = y_offset
             self.tree.links.new(split_node.outputs[1], y_node.inputs[0])
             self.tree.links.new(y_node.outputs[0], combine_node.inputs[1])
         

--- a/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -79,9 +79,14 @@ class NodesWrapper:
             self.tree.links.new(uv.outputs[6], b_texture_node.inputs[0])
         # use supplied UV maps for everything else, if present
         else:
-            uv = self.tree.nodes.new('ShaderNodeUVMap')
-            uv.name = "TexCoordIndex" + str(uv_index)
-            uv.uv_map = f"UV{uv_index}"
+            uv_name = "TexCoordIndex" + str(uv_index)
+            existing_node = self.tree.nodes.get(uv_name)
+            if not existing_node:
+                uv = self.tree.nodes.new('ShaderNodeUVMap')
+                uv.name = uv_name
+                uv.uv_map = f"UV{uv_index}"
+            else:
+                uv = existing_node
             self.tree.links.new(uv.outputs[0], b_texture_node.inputs[0])
             # todo [texture/anim] if present in nifs, support it and move to anim sys
             # if tex_transform or tex_anim:

--- a/io_scene_niftools/modules/nif_import/property/shader/bsshaderproperty.py
+++ b/io_scene_niftools/modules/nif_import/property/shader/bsshaderproperty.py
@@ -100,16 +100,16 @@ class BSShaderPropertyProcessor(BSShader):
         #translate the clamp, uv offset and uv scale to values to use in blender
         if hasattr(bs_shader_property, 'texture_clamp_mode'):
             clamp_mode = bs_shader_property.texture_clamp_mode
-            if clamp_mode == 3:
+            if clamp_mode == NifFormat.TexClampMode.WRAP_S_WRAP_T:
                 clamp_x = False
                 clamp_y = False
-            if clamp_mode == 2:
+            if clamp_mode == NifFormat.TexClampMode.WRAP_S_CLAMP_T:
                 clamp_x = False
                 clamp_y = True
-            if clamp_mode == 1:
+            if clamp_mode == NifFormat.TexClampMode.CLAMP_S_WRAP_T:
                 clamp_x = True
                 clamp_y = False
-            if clamp_mode == 0:
+            if clamp_mode == NifFormat.TexClampMode.CLAMP_S_CLAMP_T:
                 clamp_x = True
                 clamp_y = True
         else:
@@ -130,9 +130,9 @@ class BSShaderPropertyProcessor(BSShader):
             x_scale = 1
             y_scale = 1
 
-        b_x_offset = 1 - x_offset - x_scale
+        #only the y offset needs conversion, xoffset is the same for the same result
         b_y_offset = 1 - y_offset - y_scale
-        self._nodes_wrapper.global_uv_offset_scale(b_x_offset, b_y_offset, x_scale, y_scale, clamp_x, clamp_y)
+        self._nodes_wrapper.global_uv_offset_scale(x_scale, y_scale, x_offset, b_y_offset, clamp_x, clamp_y)
 
         # Diffuse color
         if bs_shader_property.skin_tint_color:

--- a/io_scene_niftools/modules/nif_import/property/shader/bsshaderproperty.py
+++ b/io_scene_niftools/modules/nif_import/property/shader/bsshaderproperty.py
@@ -97,15 +97,42 @@ class BSShaderPropertyProcessor(BSShader):
         # Textures
         self.texturehelper.import_bsshaderproperty_textureset(bs_shader_property, self._nodes_wrapper)
 
-        # TODO [shader] UV offset node support
-        # if hasattr(bs_shader_property, 'texture_clamp_mode'):
-        #     self.import_clamp(self.b_mat, bs_shader_property)
-        #
-        # if hasattr(bs_shader_property, 'uv_offset'):
-        #     self.import_uv_offset(self.b_mat, bs_shader_property)
-        #
-        # if hasattr(bs_shader_property, 'uv_scale'):
-        #     self.import_uv_scale(self.b_mat, bs_shader_property)
+        #translate the clamp, uv offset and uv scale to values to use in blender
+        if hasattr(bs_shader_property, 'texture_clamp_mode'):
+            clamp_mode = bs_shader_property.texture_clamp_mode
+            if clamp_mode == 3:
+                clamp_x = False
+                clamp_y = False
+            if clamp_mode == 2:
+                clamp_x = False
+                clamp_y = True
+            if clamp_mode == 1:
+                clamp_x = True
+                clamp_y = False
+            if clamp_mode == 0:
+                clamp_x = True
+                clamp_y = True
+        else:
+            clamp_x = False
+            clamp_y = False
+
+        if hasattr(bs_shader_property, 'uv_offset'):
+            x_offset = bs_shader_property.uv_offset.u
+            y_offset = bs_shader_property.uv_offset.v
+        else:
+            x_offset = 0
+            y_offset = 0
+        
+        if hasattr(bs_shader_property, 'uv_scale'):
+            x_scale = bs_shader_property.uv_scale.u
+            y_scale = bs_shader_property.uv_scale.v
+        else:
+            x_scale = 1
+            y_scale = 1
+
+        b_x_offset = 1 - x_offset - x_scale
+        b_y_offset = 1 - y_offset - y_scale
+        self._nodes_wrapper.global_uv_offset_scale(b_x_offset, b_y_offset, x_scale, y_scale, clamp_x, clamp_y)
 
         # Diffuse color
         if bs_shader_property.skin_tint_color:


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
- Normal map images are now linked correctly to the BSDF node. 
- Image texture nodes without a label, now also looks at the name of the image.
- Import and export of UV scale, UV offset and texture clamp mode for BSShaderProperty, via shader nodes.

##  Detailed Description
- Normal map image texture nodes are now set to non-color data, and linked through the normal map node (needed to convert the normal map texture to proper normal information).
- Image texture nodes without a label, now also looks at the name of the image. This is more of a quality of life feature. Previously an unlabeled node led to an error, even though it looked like the node was labelled correctly, because the image name displays as the label when it is not set.
- Import of UV scale, UV offset and texture clamp mode happens by splitting the UV Map node output into X and Y (U and V), then using math nodes (which multiply and add) separately. The splitting (instead of Vector Math nodes) happens so that there can be a separate clamp per dimension (X and Y). In principle this could also happen with four separate vector math nodes (multiple, add and minimum/maximum). There is a difference between Blender and nif: when it clips in only one direction, it takes the value of the edge pixels, rather than going to 0.
- Export of UV scale, UV offset and texture clamp mode does the reverse of the import. However, if the nodes have different names than the import gave them or they don't exist, it either traces back through the UV input of the base image texture, or assumes default values, respectively.

## Fixes Known Issues
1. Related to #81 ? (but only for BSShaderProperty)
2. Fixed missing `Has_Tangents` flag #404 , which caused the tangents to also be generated.

## Documentation
**[Overview of updates to documentation]**

## Testing
- Import a nif with non-standard UV scale, offset and wrap, See that it produces the same result in Blender, and that the values are again the same when exporting that.

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
BSEffectShaderProperty has similar fields. May change so that it works for that, too in the future. Should not be too difficult, as most of the values are the same, though the texture clamp mode is byte instead of TexClampMode.