### PR TITLE
Cleanup of uv transform handling and texture slot name use, and change to glossiness import

### DIFF
--- a/docs/user/features/properties/material.rst
+++ b/docs/user/features/properties/material.rst
@@ -67,12 +67,13 @@ This value sets how much light the material emits.
 Gloss
 ~~~~~
 
-This value sets how diffuse the specular highlight across the material.
+This value sets how diffuse the specular highlight across the material. Higher values of gloss(iness) mean that the
+highlight is sharper/smaller.
 
-#. In the **Specular** panel
-#. Set the **Hardness** 
-
-* This value is used to set how intense the specular highlight should be.
+#. In the **Surface** panel, deactivate the "Use Nodes" setting (setting the roughness of the BSDF node does nothing at
+   the moment).
+#. Set the **Roughness**. This is roughly the inverse of the gloss, calculated via roughness = 1/(gloss + 1)
+#. Reactivate the "Use Nodes" setting. This is needed because otherwise the exporter needs nodes for textures etc.
 
 Specular
 ~~~~~~~~

--- a/io_scene_niftools/modules/nif_export/property/material/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/material/__init__.py
@@ -100,7 +100,7 @@ class MaterialProp:
         n_mat_prop.emissive_color.b = emissive.b
 
         # gloss mat 'Hardness' scrollbar in Blender, takes values between 1 and 511 (MW -> 0.0 - 128.0)
-        n_mat_prop.glossiness = b_mat.specular_intensity
+        n_mat_prop.glossiness = min(1/b_mat.roughness - 1, 128) if b_mat.roughness != 0 else 128
         n_mat_prop.alpha = b_mat.niftools.emissive_alpha.v
         # todo [material] this float is used by FO3's material properties
         # n_mat_prop.emit_multi = emitmulti

--- a/io_scene_niftools/modules/nif_export/property/material/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/material/__init__.py
@@ -99,7 +99,7 @@ class MaterialProp:
         n_mat_prop.emissive_color.g = emissive.g
         n_mat_prop.emissive_color.b = emissive.b
 
-        # gloss mat 'Hardness' scrollbar in Blender, takes values between 1 and 511 (MW -> 0.0 - 128.0)
+        # map roughness [0,1] to glossiness (MW -> 0.0 - 128.0)
         n_mat_prop.glossiness = min(1/b_mat.roughness - 1, 128) if b_mat.roughness != 0 else 128
         n_mat_prop.alpha = b_mat.niftools.emissive_alpha.v
         # todo [material] this float is used by FO3's material properties

--- a/io_scene_niftools/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/shader/__init__.py
@@ -41,6 +41,7 @@ from pyffi.formats.nif import NifFormat
 import io_scene_niftools.utils.logging
 from io_scene_niftools.modules.nif_export.property.texture.types.bsshadertexture import BSShaderTexture
 from io_scene_niftools.utils import math
+from io_scene_niftools.utils.consts import FLOAT_MAX
 
 
 class BSShaderProperty:
@@ -118,7 +119,7 @@ class BSShaderProperty:
         # bsshader.emissive_multiple = b_mat.emit
 
         # gloss
-        bsshader.glossiness = b_mat.roughness
+        bsshader.glossiness = 1/b_mat.roughness - 1 if b_mat.roughness != 0 else FLOAT_MAX
 
         # Specular color
         s = b_mat.specular_color

--- a/io_scene_niftools/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/shader/__init__.py
@@ -78,9 +78,6 @@ class BSShaderProperty:
         # if b_mat.use_transparency:
         #     bsshader.alpha = (1 - b_mat.alpha)
 
-        # clamp Mode
-        bsshader.texture_clamp_mode = 65283
-
         # Emissive
         bsshader.emissive_color.r = b_mat.niftools.emissive_color.r
         bsshader.emissive_color.g = b_mat.niftools.emissive_color.g

--- a/io_scene_niftools/modules/nif_export/property/texture/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/__init__.py
@@ -43,6 +43,7 @@ from io_scene_niftools.modules.nif_export.animation.texture import TextureAnimat
 from io_scene_niftools.modules.nif_export.property import texture
 from io_scene_niftools.modules.nif_export.property.texture.writer import TextureWriter
 from io_scene_niftools.utils.logging import NifLog, NifError
+from io_scene_niftools.utils.consts import TEX_SLOTS
 
 
 class TextureSlotManager:
@@ -57,20 +58,9 @@ class TextureSlotManager:
         self._reset_fields()
 
     def _reset_fields(self):
-        self.slots = {
-                "Base": None,
-                "Dark": None,
-                "Detail": None,
-                "Gloss": None,
-                "Glow": None,
-                "Bump Map": None,
-                "Decal 0": None,
-                "Decal 1": None,
-                "Decal 2": None,
-                # extra shader stuff?
-                "Specular": None,
-                "Normal": None,
-        }
+        self.slots = {}
+        for slot_name in vars(TEX_SLOTS).values():
+            self.slots[slot_name] = None
     
     def get_input_node_of_type(self, input_socket, node_types):
         #search back in the node tree for nodes of a certain type(s), depth-first

--- a/io_scene_niftools/modules/nif_export/property/texture/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/__init__.py
@@ -61,28 +61,28 @@ class TextureSlotManager:
         self.slots = {}
         for slot_name in vars(TEX_SLOTS).values():
             self.slots[slot_name] = None
-    
+
     def get_input_node_of_type(self, input_socket, node_types):
-        #search back in the node tree for nodes of a certain type(s), depth-first
+        # search back in the node tree for nodes of a certain type(s), depth-first
         links = input_socket.links
         if not links:
-            #this socket has no inputs
+            # this socket has no inputs
             return None
         node = links[0].from_node
         if isinstance(node, node_types):
-            #the input node is of the required type
+            # the input node is of the required type
             return node
         else:
             if len(node.inputs) > 0:
                 for input in node.inputs:
-                    #check every input if somewhere up that tree is a node of the required type
+                    # check every input if somewhere up that tree is a node of the required type
                     input_results = self.get_input_node_of_type(input, node_types)
                     if input_results:
                         return input_results
-                #we found nothing
+                # we found nothing
                 return None
             else:
-                #this has no inputs, and doesn't classify itself
+                # this has no inputs, and doesn't classify itself
                 return None
 
     def get_uv_node(self, b_texture_node):
@@ -90,7 +90,7 @@ class TextureSlotManager:
         if uv_node is None:
             links = b_texture_node.inputs[0].links
             if not links:
-                #nothing is plugged in, so it will use the first UV map
+                # nothing is plugged in, so it will use the first UV map
                 return 0
         if isinstance(uv_node, bpy.types.ShaderNodeUVMap):
             uv_name = uv_node.uv_map
@@ -106,21 +106,21 @@ class TextureSlotManager:
                            f"Expected 'UV Map' or 'Texture Coordinate' nodes")
 
     def get_global_uv_transform_clip(self):
-        #get the values from the nodes, find the nodes by name, or search back in the node tree
+        # get the values from the nodes, find the nodes by name, or search back in the node tree
         x_scale = y_scale = x_offset = y_offset = clamp_x = clamp_y = None
-        #first check if there are any of the preset name - much more time efficient
+        # first check if there are any of the preset name - much more time efficient
         try:
             combine_node = self.b_mat.node_tree.nodes["Combine UV0"]
             if not isinstance(combine_node, bpy.types.ShaderNodeCombineXYZ):
                 combine_node = None
                 NifLog.warn(f"Found node with name 'Combine UV0', but it was of the wrong type.")
         except:
-            #if there is a combine node, it does not have the standard name
+            # if there is a combine node, it does not have the standard name
             combine_node = None
             NifLog.warn(f"Did not find node with 'Combine UV0' name.")
 
         if combine_node is None:
-            #did not find a (correct) combine node, search through the first existing texture node vector input
+            # did not find a (correct) combine node, search through the first existing texture node vector input
             b_texture_node = None
             for slot_name, slot_node in self.slots.items():
                 if slot_node is not None:
@@ -133,8 +133,8 @@ class TextureSlotManager:
             x_link = combine_node.inputs[0].links
             if x_link:
                 x_node = x_link[0].from_node
-                x_scale =  x_node.inputs[1].default_value
-                x_offset =  x_node.inputs[2].default_value
+                x_scale = x_node.inputs[1].default_value
+                x_offset = x_node.inputs[2].default_value
                 clamp_x = x_node.use_clamp
             y_link = combine_node.inputs[1].links
             if y_link:
@@ -184,4 +184,4 @@ class TextureSlotManager:
             # unsupported texture type
             else:
                 raise NifError(f"Do not know how to export texture node '{b_texture_node.name}' in material '{b_mat.name}' with label '{shown_label}'."
-                                         f"Delete it or change its label.")
+                               f"Delete it or change its label.")

--- a/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -69,7 +69,7 @@ class BSShaderTexture(TextureSlotManager):
         if self.slots[TEX_SLOTS.GLOW]:
             bsshader.greyscale_texture = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.GLOW])
 
-        #get the offset, scale and UV wrapping mode and set them
+        # get the offset, scale and UV wrapping mode and set them
         self.export_uv_transform(bsshader)
 
     def export_bs_lighting_shader_prop_textures(self, bsshader):
@@ -86,9 +86,8 @@ class BSShaderTexture(TextureSlotManager):
         if self.slots[TEX_SLOTS.GLOSS]:
             texset.textures[7] = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.GLOSS])
 
-        #get the offset, scale and UV wrapping mode and set them
+        # get the offset, scale and UV wrapping mode and set them
         self.export_uv_transform(bsshader)
-
 
     def export_bs_shader_pp_lighting_prop_textures(self, bsshader):
         bsshader.texture_set = self._create_textureset()
@@ -111,9 +110,9 @@ class BSShaderTexture(TextureSlotManager):
         return texset
 
     def export_uv_transform(self, shader):
-        #get the offset, scale and UV wrapping mode and set them
+        # get the offset, scale and UV wrapping mode and set them
         x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_global_uv_transform_clip()
-        #default values for if they haven't been defined:
+        # default values for if they haven't been defined:
         if x_scale is None:
             x_scale = 1
         if y_scale is None:
@@ -123,7 +122,7 @@ class BSShaderTexture(TextureSlotManager):
         if y_offset is None:
             y_offset = 0
         else:
-            #need to translate blender offset to nif offset to get the same results
+            # need to translate blender offset to nif offset to get the same results
             y_offset = 1 - y_scale - y_offset
         if clamp_x is None:
             clamp_x = False
@@ -141,10 +140,10 @@ class BSShaderTexture(TextureSlotManager):
         # Texture Clamping mode
         if hasattr(shader, 'texture_clamp_mode'):
             if self.slots[TEX_SLOTS.BASE] and (self.slots[TEX_SLOTS.BASE].extension == "CLIP"):
-                #if the extension is clip, we know the wrap mode is clamp for both,
+                # if the extension is clip, we know the wrap mode is clamp for both,
                 shader.texture_clamp_mode = (shader.texture_clamp_mode - shader.texture_clamp_mode % 256) + NifFormat.TexClampMode.CLAMP_S_CLAMP_T
             else:
-                #otherwise, look at the given clip modes from the nodes
+                # otherwise, look at the given clip modes from the nodes
                 if not clamp_x:
                     wrap_s = 2
                 else:

--- a/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -112,7 +112,7 @@ class BSShaderTexture(TextureSlotManager):
 
     def export_uv_transform(self, shader):
         #get the offset, scale and UV wrapping mode and set them
-        x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_global_uv_transform_clip(self.slots[TEX_SLOTS.BASE])
+        x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_global_uv_transform_clip()
         #default values for if they haven't been defined:
         if x_scale is None:
             x_scale = 1
@@ -140,7 +140,7 @@ class BSShaderTexture(TextureSlotManager):
 
         # Texture Clamping mode
         if hasattr(shader, 'texture_clamp_mode'):
-            if self.slots[TEX_SLOTS.BASE].extension == "CLIP":
+            if self.slots[TEX_SLOTS.BASE] and (self.slots[TEX_SLOTS.BASE].extension == "CLIP"):
                 #if the extension is clip, we know the wrap mode is clamp for both,
                 shader.texture_clamp_mode = (shader.texture_clamp_mode - shader.texture_clamp_mode % 256) + NifFormat.TexClampMode.CLAMP_S_CLAMP_T
             else:
@@ -153,6 +153,6 @@ class BSShaderTexture(TextureSlotManager):
                     wrap_t = 1
                 else:
                     wrap_t = 0
-                shader.texture_clamp_mode = (shader.texture_clamp_mode - shader.texture_clamp_mode % 256) + + (wrap_s + wrap_t)
+                shader.texture_clamp_mode = (shader.texture_clamp_mode - shader.texture_clamp_mode % 256) + (wrap_s + wrap_t)
 
         return shader

--- a/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -68,8 +68,8 @@ class BSShaderTexture(TextureSlotManager):
         if self.slots["Glow"]:
             bsshader.greyscale_texture = TextureWriter.export_texture_filename(self.slots["Glow"])
 
-        # clamp Mode
-        bsshader.texture_clamp_mode = 65283
+        #get the offset, scale and UV wrapping mode and set them
+        self.export_uv_transform(bsshader)
 
     def export_bs_lighting_shader_prop_textures(self, bsshader):
         texset = self._create_textureset()
@@ -86,48 +86,8 @@ class BSShaderTexture(TextureSlotManager):
             texset.textures[7] = TextureWriter.export_texture_filename(self.slots["Gloss"])
 
         #get the offset, scale and UV wrapping mode and set them
-        x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_global_uv_transform_clip(self.slots["Base"])
-        #default values for if they haven't been defined:
-        if x_scale is None:
-            x_scale = 1
-        if y_scale is None:
-            y_scale = 1
-        if x_offset is None:
-            x_offset = 0
-        if y_offset is None:
-            y_offset = 0
-        else:
-            #need to translate blender offset to nif offset to get the same results
-            y_offset = 1 - y_scale - y_offset
-        if clamp_x is None:
-            clamp_x = False
-        if clamp_y is None:
-            clamp_y = False
+        self.export_uv_transform(bsshader)
 
-        if hasattr(bsshader, "uv_scale"):
-            bsshader.uv_scale.u = x_scale
-            bsshader.uv_scale.v = y_scale
-
-        if hasattr(bsshader, 'uv_offset'):
-            bsshader.uv_offset.u = x_offset
-            bsshader.uv_offset.v = y_offset
-
-        # Texture Clamping mode
-        b_img = self.slots["Base"].image
-        if self.slots["Base"].extension == "CLIP":
-            #if the extension is clip, we know the wrap mode is clamp for both,
-            bsshader.texture_clamp_mode = NifFormat.TexClampMode.CLAMP_S_CLAMP_T
-        else:
-            #otherwise, look at the given clip modes from the nodes
-            if not clamp_x:
-                wrap_s = 2
-            else:
-                wrap_s = 0
-            if not clamp_y:
-                wrap_t = 1
-            else:
-                wrap_t = 0
-            bsshader.texture_clamp_mode = (wrap_s + wrap_t)
 
     def export_bs_shader_pp_lighting_prop_textures(self, bsshader):
         bsshader.texture_set = self._create_textureset()
@@ -148,6 +108,53 @@ class BSShaderTexture(TextureSlotManager):
             texset.textures[3] = TextureWriter.export_texture_filename(self.slots["Detail"])
 
         return texset
+
+    def export_uv_transform(self, shader):
+        #get the offset, scale and UV wrapping mode and set them
+        x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_global_uv_transform_clip(self.slots["Base"])
+        #default values for if they haven't been defined:
+        if x_scale is None:
+            x_scale = 1
+        if y_scale is None:
+            y_scale = 1
+        if x_offset is None:
+            x_offset = 0
+        if y_offset is None:
+            y_offset = 0
+        else:
+            #need to translate blender offset to nif offset to get the same results
+            y_offset = 1 - y_scale - y_offset
+        if clamp_x is None:
+            clamp_x = False
+        if clamp_y is None:
+            clamp_y = False
+
+        if hasattr(shader, "uv_scale"):
+            shader.uv_scale.u = x_scale
+            shader.uv_scale.v = y_scale
+
+        if hasattr(shader, 'uv_offset'):
+            shader.uv_offset.u = x_offset
+            shader.uv_offset.v = y_offset
+
+        # Texture Clamping mode
+        if hasattr(shader, 'texture_clamp_mode'):
+            if self.slots["Base"].extension == "CLIP":
+                #if the extension is clip, we know the wrap mode is clamp for both,
+                shader.texture_clamp_mode = (shader.texture_clamp_mode - shader.texture_clamp_mode % 256) + NifFormat.TexClampMode.CLAMP_S_CLAMP_T
+            else:
+                #otherwise, look at the given clip modes from the nodes
+                if not clamp_x:
+                    wrap_s = 2
+                else:
+                    wrap_s = 0
+                if not clamp_y:
+                    wrap_t = 1
+                else:
+                    wrap_t = 0
+                shader.texture_clamp_mode = (shader.texture_clamp_mode - shader.texture_clamp_mode % 256) + + (wrap_s + wrap_t)
+
+        return shader
 
     def export_uv_offset(self, shader):
         shader.uv_offset.u = self.slots["Base"].offset.x

--- a/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -39,6 +39,7 @@
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.modules.nif_export.property.texture import TextureWriter, TextureSlotManager
+from io_scene_niftools.utils.consts import TEX_SLOTS
 
 
 class BSShaderTexture(TextureSlotManager):
@@ -63,10 +64,10 @@ class BSShaderTexture(TextureSlotManager):
     def export_bs_effect_shader_prop_textures(self, bsshader):
         bsshader.texture_set = self._create_textureset()
 
-        if self.slots["Base"]:
-            bsshader.source_texture = TextureWriter.export_texture_filename(self.slots["Base"])
-        if self.slots["Glow"]:
-            bsshader.greyscale_texture = TextureWriter.export_texture_filename(self.slots["Glow"])
+        if self.slots[TEX_SLOTS.BASE]:
+            bsshader.source_texture = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.BASE])
+        if self.slots[TEX_SLOTS.GLOW]:
+            bsshader.greyscale_texture = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.GLOW])
 
         #get the offset, scale and UV wrapping mode and set them
         self.export_uv_transform(bsshader)
@@ -79,11 +80,11 @@ class BSShaderTexture(TextureSlotManager):
         texset.num_textures = 9
         texset.textures.update_size()
 
-        if self.slots["Detail"]:
-            texset.textures[6] = TextureWriter.export_texture_filename(self.slots["Detail"])
+        if self.slots[TEX_SLOTS.DETAIL]:
+            texset.textures[6] = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.DETAIL])
 
-        if self.slots["Gloss"]:
-            texset.textures[7] = TextureWriter.export_texture_filename(self.slots["Gloss"])
+        if self.slots[TEX_SLOTS.GLOSS]:
+            texset.textures[7] = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.GLOSS])
 
         #get the offset, scale and UV wrapping mode and set them
         self.export_uv_transform(bsshader)
@@ -95,23 +96,23 @@ class BSShaderTexture(TextureSlotManager):
     def _create_textureset(self):
         texset = NifFormat.BSShaderTextureSet()
 
-        if self.slots["Base"]:
-            texset.textures[0] = TextureWriter.export_texture_filename(self.slots["Base"])
+        if self.slots[TEX_SLOTS.BASE]:
+            texset.textures[0] = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.BASE])
 
-        if self.slots["Normal"]:
-            texset.textures[1] = TextureWriter.export_texture_filename(self.slots["Normal"])
+        if self.slots[TEX_SLOTS.NORMAL]:
+            texset.textures[1] = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.NORMAL])
 
-        if self.slots["Glow"]:
-            texset.textures[2] = TextureWriter.export_texture_filename(self.slots["Glow"])
+        if self.slots[TEX_SLOTS.GLOW]:
+            texset.textures[2] = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.GLOW])
 
-        if self.slots["Detail"]:
-            texset.textures[3] = TextureWriter.export_texture_filename(self.slots["Detail"])
+        if self.slots[TEX_SLOTS.DETAIL]:
+            texset.textures[3] = TextureWriter.export_texture_filename(self.slots[TEX_SLOTS.DETAIL])
 
         return texset
 
     def export_uv_transform(self, shader):
         #get the offset, scale and UV wrapping mode and set them
-        x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_global_uv_transform_clip(self.slots["Base"])
+        x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_global_uv_transform_clip(self.slots[TEX_SLOTS.BASE])
         #default values for if they haven't been defined:
         if x_scale is None:
             x_scale = 1
@@ -139,7 +140,7 @@ class BSShaderTexture(TextureSlotManager):
 
         # Texture Clamping mode
         if hasattr(shader, 'texture_clamp_mode'):
-            if self.slots["Base"].extension == "CLIP":
+            if self.slots[TEX_SLOTS.BASE].extension == "CLIP":
                 #if the extension is clip, we know the wrap mode is clamp for both,
                 shader.texture_clamp_mode = (shader.texture_clamp_mode - shader.texture_clamp_mode % 256) + NifFormat.TexClampMode.CLAMP_S_CLAMP_T
             else:

--- a/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_niftools/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -155,15 +155,3 @@ class BSShaderTexture(TextureSlotManager):
                 shader.texture_clamp_mode = (shader.texture_clamp_mode - shader.texture_clamp_mode % 256) + + (wrap_s + wrap_t)
 
         return shader
-
-    def export_uv_offset(self, shader):
-        shader.uv_offset.u = self.slots["Base"].offset.x
-        shader.uv_offset.v = self.slots["Base"].offset.y
-
-        return shader
-
-    def export_uv_scale(self, shader):
-        shader.uv_scale.u = self.slots["Base"].scale.x
-        shader.uv_scale.v = self.slots["Base"].scale.y
-
-        return shader

--- a/io_scene_niftools/modules/nif_import/property/material/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/material/__init__.py
@@ -93,8 +93,9 @@ class Material:
 
     @staticmethod
     def import_material_gloss(b_mat, glossiness):
-        # b_mat.specular_hardness = glossiness
-        b_mat.roughness = glossiness  # Blender multiplies specular color with this value
+        # convert glossiness, range [0,inf), with high values leading to sharp reflections, to roughness, range [0,1],
+        # where low values give sharp reflections
+        b_mat.roughness = 1/(glossiness+1)
 
     @staticmethod
     def import_material_alpha(b_mat, n_alpha):

--- a/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -108,7 +108,7 @@ class NodesWrapper:
             #                 transform.keyframe_insert("translation", index=j, frame=int(key[0] * fps))
             #     tree.links.new(uv.outputs[0], transform.inputs[0])
             #     tree.links.new(transform.outputs[0], tex.inputs[0])
-        
+
     def global_uv_offset_scale(self, x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y):
         # get all uv nodes (by name, since we are importing they have the predefined name
         # and then we don't have to loop through every node
@@ -119,34 +119,33 @@ class NodesWrapper:
             uv_node = self.tree.nodes.get(uv_name)
             if uv_node and isinstance(uv_node, bpy.types.ShaderNodeUVMap):
                 uv_nodes[uv_name] = uv_node
-                i +=1
+                i += 1
             else:
                 break
-        
 
         clip_texture = clamp_x and clamp_y
 
         for uv_name, uv_node in uv_nodes.items():
-            #for each of those, create a new uv output node and relink
+            # for each of those, create a new uv output node and relink
             split_node = self.tree.nodes.new("ShaderNodeSeparateXYZ")
             split_node.name = "Separate UV" + uv_name[-1]
             split_node.label = split_node.name
             combine_node = self.tree.nodes.new("ShaderNodeCombineXYZ")
             combine_node.name = "Combine UV" + uv_name[-1]
             combine_node.label = combine_node.name
-            
+
             x_node = self.tree.nodes.new("ShaderNodeMath")
             x_node.name = "X offset and scale UV" + uv_name[-1]
             x_node.label = x_node.name
             x_node.operation = 'MULTIPLY_ADD'
-            #only clamp on the math node when we're not clamping on both directions
-            #otherwise, the clip on the image texture node will take care of it
+            # only clamp on the math node when we're not clamping on both directions
+            # otherwise, the clip on the image texture node will take care of it
             x_node.use_clamp = clamp_x and not clip_texture
             x_node.inputs[1].default_value = x_scale
             x_node.inputs[2].default_value = x_offset
             self.tree.links.new(split_node.outputs[0], x_node.inputs[0])
             self.tree.links.new(x_node.outputs[0], combine_node.inputs[0])
-            
+
             y_node = self.tree.nodes.new("ShaderNodeMath")
             y_node.name = "Y offset and scale UV" + uv_name[-1]
             y_node.label = y_node.name
@@ -156,21 +155,21 @@ class NodesWrapper:
             y_node.inputs[2].default_value = y_offset
             self.tree.links.new(split_node.outputs[1], y_node.inputs[0])
             self.tree.links.new(y_node.outputs[0], combine_node.inputs[1])
-        
-            #get all the texture nodes to which it is linked, and re-link them to the uv output node
+
+            # get all the texture nodes to which it is linked, and re-link them to the uv output node
             for link in uv_node.outputs[0].links:
-                #get the target link/socket
+                # get the target link/socket
                 target_node = link.to_node
                 if isinstance(link.to_node, bpy.types.ShaderNodeTexImage):
                     target_socket = link.to_socket
-                    #delete the existing link
+                    # delete the existing link
                     self.tree.links.remove(link)
-                    #make new ones
+                    # make new ones
                     self.tree.links.new(combine_node.outputs[0], target_socket)
-                    #if we clamp in both directions, clip the images:
+                    # if we clamp in both directions, clip the images:
                     if clip_texture:
                         target_node.extension = 'CLIP'
-            self.tree.links.new(uv_node.outputs[0],split_node.inputs[0])
+            self.tree.links.new(uv_node.outputs[0], split_node.inputs[0])
         pass
 
     def clear_default_nodes(self):
@@ -306,12 +305,12 @@ class NodesWrapper:
 
     def link_normal_node(self, b_texture_node):
         b_texture_node.label = TEX_SLOTS.NORMAL
-        #set to non-color data
+        # set to non-color data
         b_texture_node.image.colorspace_settings.name = 'Non-Color'
-        #create tangent normal map converter and link to it
+        # create tangent normal map converter and link to it
         tangent_converter = self.b_mat.node_tree.nodes.new("ShaderNodeNormalMap")
         self.tree.links.new(b_texture_node.outputs[0], tangent_converter.inputs[1])
-        #link to the diffuse shader
+        # link to the diffuse shader
         self.tree.links.new(tangent_converter.outputs[0], self.diffuse_shader.inputs[2])
         # # Influence mapping
         # b_texture_node.texture.use_normal_map = True  # causes artifacts otherwise.

--- a/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -44,6 +44,7 @@ from io_scene_niftools.modules.nif_import.geometry.vertex import Vertex
 from io_scene_niftools.modules.nif_import.property.texture.loader import TextureLoader
 from io_scene_niftools.utils.logging import NifLog
 from io_scene_niftools.utils.nodes import nodes_iterate
+from io_scene_niftools.utils.consts import TEX_SLOTS
 
 
 # TODO [property][texture] Move IMPORT_EMBEDDED_TEXTURES as a import property
@@ -286,11 +287,11 @@ class NodesWrapper:
 
     def link_base_node(self, b_texture_node):
         self.diffuse_texture = b_texture_node
-        b_texture_node.label = "Base"
+        b_texture_node.label = TEX_SLOTS.BASE
         self.diffuse_pass = self.connect_to_pass(self.diffuse_pass, b_texture_node)
 
     def link_bump_map_node(self, b_texture_node):
-        b_texture_node.label = "Bump Map"
+        b_texture_node.label = TEX_SLOTS.BUMP_MAP
         # # Influence mapping
         # b_texture_node.texture.use_normal_map = False  # causes artifacts otherwise.
         #
@@ -304,7 +305,7 @@ class NodesWrapper:
         # b_texture_node.use_map_alpha = False
 
     def link_normal_node(self, b_texture_node):
-        b_texture_node.label = "Normal"
+        b_texture_node.label = TEX_SLOTS.NORMAL
         #set to non-color data
         b_texture_node.image.colorspace_settings.name = 'Non-Color'
         #create tangent normal map converter and link to it
@@ -325,7 +326,7 @@ class NodesWrapper:
         # b_texture_node.use_map_alpha = False
 
     def link_glow_node(self, b_texture_node):
-        b_texture_node.label = "Glow"
+        b_texture_node.label = TEX_SLOTS.GLOW
         # # Influence mapping
         # b_texture_node.texture.use_alpha = False
         #
@@ -338,7 +339,7 @@ class NodesWrapper:
         # b_texture_node.use_map_emit = True
 
     def link_gloss_node(self, b_texture_node):
-        b_texture_node.label = "Gloss"
+        b_texture_node.label = TEX_SLOTS.GLOSS
         # # Influence mapping
         # b_texture_node.texture.use_alpha = False
         #
@@ -352,23 +353,23 @@ class NodesWrapper:
         # b_texture_node.use_map_color_spec = True
 
     def link_decal_0_node(self, b_texture_node):
-        b_texture_node.label = "Decal 0"
+        b_texture_node.label = TEX_SLOTS.DECAL_0
         self.diffuse_pass = self.connect_to_pass(self.diffuse_pass, b_texture_node, texture_type="Decal")
 
     def link_decal_1_node(self, b_texture_node):
-        b_texture_node.label = "Decal 1"
+        b_texture_node.label = TEX_SLOTS.DECAL_1
         self.diffuse_pass = self.connect_to_pass(self.diffuse_pass, b_texture_node, texture_type="Decal")
 
     def link_decal_2_node(self, b_texture_node):
-        b_texture_node.label = "Decal2"
+        b_texture_node.label = TEX_SLOTS.DECAL_2
         self.diffuse_pass = self.connect_to_pass(self.diffuse_pass, b_texture_node, texture_type="Decal")
 
     def link_detail_node(self, b_texture_node):
-        b_texture_node.label = "Detail"
+        b_texture_node.label = TEX_SLOTS.DETAIL
         self.diffuse_pass = self.connect_to_pass(self.diffuse_pass, b_texture_node, texture_type="Detail")
 
     def link_dark_node(self, b_texture_node):
-        b_texture_node.label = "Dark"
+        b_texture_node.label = TEX_SLOTS.DARK
 
     def link_reflection_node(self, b_texture_node):
         # Influence mapping

--- a/io_scene_niftools/modules/nif_import/property/shader/bsshaderproperty.py
+++ b/io_scene_niftools/modules/nif_import/property/shader/bsshaderproperty.py
@@ -97,42 +97,9 @@ class BSShaderPropertyProcessor(BSShader):
         # Textures
         self.texturehelper.import_bsshaderproperty_textureset(bs_shader_property, self._nodes_wrapper)
 
-        #translate the clamp, uv offset and uv scale to values to use in blender
-        if hasattr(bs_shader_property, 'texture_clamp_mode'):
-            clamp_mode = bs_shader_property.texture_clamp_mode
-            if clamp_mode == NifFormat.TexClampMode.WRAP_S_WRAP_T:
-                clamp_x = False
-                clamp_y = False
-            if clamp_mode == NifFormat.TexClampMode.WRAP_S_CLAMP_T:
-                clamp_x = False
-                clamp_y = True
-            if clamp_mode == NifFormat.TexClampMode.CLAMP_S_WRAP_T:
-                clamp_x = True
-                clamp_y = False
-            if clamp_mode == NifFormat.TexClampMode.CLAMP_S_CLAMP_T:
-                clamp_x = True
-                clamp_y = True
-        else:
-            clamp_x = False
-            clamp_y = False
+        x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_uv_transform(bs_shader_property)
 
-        if hasattr(bs_shader_property, 'uv_offset'):
-            x_offset = bs_shader_property.uv_offset.u
-            y_offset = bs_shader_property.uv_offset.v
-        else:
-            x_offset = 0
-            y_offset = 0
-        
-        if hasattr(bs_shader_property, 'uv_scale'):
-            x_scale = bs_shader_property.uv_scale.u
-            y_scale = bs_shader_property.uv_scale.v
-        else:
-            x_scale = 1
-            y_scale = 1
-
-        #only the y offset needs conversion, xoffset is the same for the same result
-        b_y_offset = 1 - y_offset - y_scale
-        self._nodes_wrapper.global_uv_offset_scale(x_scale, y_scale, x_offset, b_y_offset, clamp_x, clamp_y)
+        self._nodes_wrapper.global_uv_offset_scale(x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y)
 
         # Diffuse color
         if bs_shader_property.skin_tint_color:
@@ -172,12 +139,9 @@ class BSShaderPropertyProcessor(BSShader):
 
         self.texturehelper.import_bseffectshaderproperty_textures(bs_effect_shader_property, self._nodes_wrapper)
 
-        # todo [material] update for nodes
-        # if hasattr(bs_effect_shader_property, 'uv_offset'):
-        #     self.import_uv_offset(self.b_mat, bs_effect_shader_property)
-        #
-        # if hasattr(bs_effect_shader_property, 'uv_scale'):
-        #     self.import_uv_scale(self.b_mat, bs_effect_shader_property)
+        x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_uv_transform(bs_effect_shader_property)
+        
+        self._nodes_wrapper.global_uv_offset_scale(x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y)
 
         # TODO [material][shader][property] Handle nialphaproperty node lookup
         # # Alpha
@@ -202,3 +166,49 @@ class BSShaderPropertyProcessor(BSShader):
 
         flag_2 = b_prop.shader_flags_2
         self.import_flags(self._b_mat, flag_2)
+
+    def get_uv_transform(self, shader):
+        #get the uv scale and offset from the shader (used by BSLightingShaderProperty, BSEffectShaderProperty, 
+        #BSWaterShaderProperty and BSSkyShaderProperty, according to nif.xml)
+        if hasattr(shader, 'uv_offset'):
+            x_offset = shader.uv_offset.u
+            y_offset = shader.uv_offset.v
+        else:
+            x_offset = 0
+            y_offset = 0
+
+        if hasattr(shader, 'uv_scale'):
+            x_scale = shader.uv_scale.u
+            y_scale = shader.uv_scale.v
+        else:
+            x_scale = 1
+            y_scale = 1
+
+        #only the y offset needs conversion, xoffset is the same for the same result
+        b_y_offset = 1 - y_offset - y_scale
+
+        #get the clamp (x and y direction)
+        if hasattr(shader, 'texture_clamp_mode'):
+            #use modulo 256, because in BSEffectShaderProperty, pyffi also takes other bytes, making the value appear
+            #higher than it is
+            clamp_mode = shader.texture_clamp_mode % 256
+            if clamp_mode == NifFormat.TexClampMode.WRAP_S_WRAP_T:
+                clamp_x = False
+                clamp_y = False
+            elif clamp_mode == NifFormat.TexClampMode.WRAP_S_CLAMP_T:
+                clamp_x = False
+                clamp_y = True
+            elif clamp_mode == NifFormat.TexClampMode.CLAMP_S_WRAP_T:
+                clamp_x = True
+                clamp_y = False
+            elif clamp_mode == NifFormat.TexClampMode.CLAMP_S_CLAMP_T:
+                clamp_x = True
+                clamp_y = True
+            else:
+                clamp_x = False
+                clamp_y = False
+        else:
+            clamp_x = False
+            clamp_y = False
+
+        return x_scale, y_scale, x_offset, b_y_offset, clamp_x, clamp_y

--- a/io_scene_niftools/modules/nif_import/property/shader/bsshaderproperty.py
+++ b/io_scene_niftools/modules/nif_import/property/shader/bsshaderproperty.py
@@ -140,7 +140,7 @@ class BSShaderPropertyProcessor(BSShader):
         self.texturehelper.import_bseffectshaderproperty_textures(bs_effect_shader_property, self._nodes_wrapper)
 
         x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y = self.get_uv_transform(bs_effect_shader_property)
-        
+
         self._nodes_wrapper.global_uv_offset_scale(x_scale, y_scale, x_offset, y_offset, clamp_x, clamp_y)
 
         # TODO [material][shader][property] Handle nialphaproperty node lookup
@@ -168,8 +168,8 @@ class BSShaderPropertyProcessor(BSShader):
         self.import_flags(self._b_mat, flag_2)
 
     def get_uv_transform(self, shader):
-        #get the uv scale and offset from the shader (used by BSLightingShaderProperty, BSEffectShaderProperty, 
-        #BSWaterShaderProperty and BSSkyShaderProperty, according to nif.xml)
+        # get the uv scale and offset from the shader (used by BSLightingShaderProperty, BSEffectShaderProperty,
+        # BSWaterShaderProperty and BSSkyShaderProperty, according to nif.xml)
         if hasattr(shader, 'uv_offset'):
             x_offset = shader.uv_offset.u
             y_offset = shader.uv_offset.v
@@ -184,13 +184,13 @@ class BSShaderPropertyProcessor(BSShader):
             x_scale = 1
             y_scale = 1
 
-        #only the y offset needs conversion, xoffset is the same for the same result
+        # only the y offset needs conversion, xoffset is the same for the same result
         b_y_offset = 1 - y_offset - y_scale
 
-        #get the clamp (x and y direction)
+        # get the clamp (x and y direction)
         if hasattr(shader, 'texture_clamp_mode'):
-            #use modulo 256, because in BSEffectShaderProperty, pyffi also takes other bytes, making the value appear
-            #higher than it is
+            # use modulo 256, because in BSEffectShaderProperty, pyffi also takes other bytes, making the value appear
+            # higher than it is
             clamp_mode = shader.texture_clamp_mode % 256
             if clamp_mode == NifFormat.TexClampMode.WRAP_S_WRAP_T:
                 clamp_x = False

--- a/io_scene_niftools/modules/nif_import/property/texture/types/bsshadertexture.py
+++ b/io_scene_niftools/modules/nif_import/property/texture/types/bsshadertexture.py
@@ -37,6 +37,7 @@
 #
 # ***** END LICENSE BLOCK *****
 from io_scene_niftools.utils.logging import NifLog
+from io_scene_niftools.utils.consts import TEX_SLOTS
 
 
 class BSShaderTexture:
@@ -62,17 +63,17 @@ class BSShaderTexture:
     def import_bsshaderproperty_textureset(self, bs_shader_property, nodes_wrapper):
         textures = bs_shader_property.texture_set.textures
         slots = {
-            "Base": 0,
-            "Normal": 1,
-            "Glow": 2,
-            "Detail": 3,
-            "Gloss": 7,
-            "Bump Map": None,
-            "Decal 0": 6,
-            "Decal 1": None,
-            "Decal 2": None,
+            TEX_SLOTS.BASE: 0,
+            TEX_SLOTS.NORMAL: 1,
+            TEX_SLOTS.GLOW: 2,
+            TEX_SLOTS.DETAIL: 3,
+            TEX_SLOTS.GLOSS: 7,
+            TEX_SLOTS.BUMP_MAP: None,
+            TEX_SLOTS.DECAL_0: 6,
+            TEX_SLOTS.DECAL_1: None,
+            TEX_SLOTS.DECAL_2: None,
             # extra shader stuff?
-            "Specular": None,
+            TEX_SLOTS.SPECULAR: None,
         }
         for slot_name, slot_i in slots.items():
             # skip those whose index we don't know from old code
@@ -87,10 +88,10 @@ class BSShaderTexture:
 
         base = bs_effect_shader_property.source_texture.decode()
         if base:
-            nodes_wrapper.create_and_link("Base", base)
+            nodes_wrapper.create_and_link(TEX_SLOTS.BASE, base)
 
         glow = bs_effect_shader_property.greyscale_texture.decode()
         if glow:
-            nodes_wrapper.create_and_link("Glow", glow)
+            nodes_wrapper.create_and_link(TEX_SLOTS.GLOW, glow)
 
         # self.import_texture_game_properties(b_mat, bs_effect_shader_property)

--- a/io_scene_niftools/modules/nif_import/property/texture/types/nitextureprop.py
+++ b/io_scene_niftools/modules/nif_import/property/texture/types/nitextureprop.py
@@ -38,6 +38,7 @@
 # ***** END LICENSE BLOCK *****
 
 from io_scene_niftools.utils.logging import NifLog
+from io_scene_niftools.utils.consts import TEX_SLOTS
 
 
 class NiTextureProp:
@@ -45,22 +46,9 @@ class NiTextureProp:
     __instance = None
 
     def __init__(self):
-        # todo [texture] merge with export slots dict, or change to simple list?
-        self.slots = {
-            "Base": None,
-            "Dark": None,
-            "Detail": None,
-            "Gloss": None,
-            "Glow": None,
-            "Bump Map": None,
-            "Decal 0": None,
-            "Decal 1": None,
-            "Decal 2": None,
-            # extra shader stuff?
-            "Specular": None,
-            "Normal": None,
-        }
-
+        self.slots = {}
+        for slot_name in vars(TEX_SLOTS).values():
+            self.slots[slot_name] = None
     def import_nitextureprop_textures(self, n_texture_desc, nodes_wrapper):
         # NifLog.debug(f"Importing {n_texture_desc}")
         # go over all valid texture slots

--- a/io_scene_niftools/modules/nif_import/property/texture/types/nitextureprop.py
+++ b/io_scene_niftools/modules/nif_import/property/texture/types/nitextureprop.py
@@ -49,6 +49,7 @@ class NiTextureProp:
         self.slots = {}
         for slot_name in vars(TEX_SLOTS).values():
             self.slots[slot_name] = None
+
     def import_nitextureprop_textures(self, n_texture_desc, nodes_wrapper):
         # NifLog.debug(f"Importing {n_texture_desc}")
         # go over all valid texture slots
@@ -62,4 +63,3 @@ class NiTextureProp:
                 NifLog.debug(f"Texdesc has active {slot_name}")
                 n_tex = getattr(n_texture_desc, field_name)
                 nodes_wrapper.create_and_link(slot_name, n_tex)
-

--- a/io_scene_niftools/utils/consts.py
+++ b/io_scene_niftools/utils/consts.py
@@ -70,15 +70,18 @@ NORMAL_RESOLUTION = 100
 LOGGER_PYFFI = "pyffi"
 LOGGER_PLUGIN = "niftools"
 
+
 class EmptyObject:
     pass
+
+
 TEX_SLOTS = EmptyObject()
 TEX_SLOTS.BASE = "Base"
 TEX_SLOTS.DARK = "Dark"
 TEX_SLOTS.DETAIL = "Detail"
 TEX_SLOTS.GLOSS = "Gloss"
 TEX_SLOTS.GLOW = "Glow"
-TEX_SLOTS.BUMP_MAP =  "Bump Map"
+TEX_SLOTS.BUMP_MAP = "Bump Map"
 TEX_SLOTS.DECAL_0 = "Decal 0"
 TEX_SLOTS.DECAL_1 = "Decal 1"
 TEX_SLOTS.DECAL_2 = "Decal 2"

--- a/io_scene_niftools/utils/consts.py
+++ b/io_scene_niftools/utils/consts.py
@@ -69,3 +69,18 @@ NORMAL_RESOLUTION = 100
 
 LOGGER_PYFFI = "pyffi"
 LOGGER_PLUGIN = "niftools"
+
+class EmptyObject:
+    pass
+TEX_SLOTS = EmptyObject()
+TEX_SLOTS.BASE = "Base"
+TEX_SLOTS.DARK = "Dark"
+TEX_SLOTS.DETAIL = "Detail"
+TEX_SLOTS.GLOSS = "Gloss"
+TEX_SLOTS.GLOW = "Glow"
+TEX_SLOTS.BUMP_MAP =  "Bump Map"
+TEX_SLOTS.DECAL_0 = "Decal 0"
+TEX_SLOTS.DECAL_1 = "Decal 1"
+TEX_SLOTS.DECAL_2 = "Decal 2"
+TEX_SLOTS.SPECULAR = "Specular"
+TEX_SLOTS.NORMAL = "Normal"


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
Import/export of UV scale, offset and clamp has been changed so that BSEffectShader now also uses it. The names of the texture slots have been pulled out to the utils/consts.py file. Glossiness import/export has been changed to allow for values higher than 1 to be correctly imported, as well as corresponding better to the effects it has on the shading of a mesh.

##  Detailed Description
- Import and export of UV scale, offset and clamp has been pulled out to their own functions, instead of being directly in the BSLightingShaderProperty import/export function.
- Import and export of UV scale, offset and clamp has been added to BSEffectShaderProperty.
- Export of UV scale, offset and clamp now functions in the absence of the base image texture node, and no longer errors if it isn't present.
- The names of the Texture nodes have been pulled out to util/consts.py as discussed.
- Glossiness is now imported/exported as roughness via `roughness = 1/(glossiness+1)`, instead of `roughness = glossiness`. This reflects the influence they have on shading (low roughness means sharp reflections, high glossiness means sharp reflections).
- The new import of glossiness also reflects their ranges (roughness [0,1], glossiness [0,inf)), whereas previous code had the issue that glossiness was never exported as >1, because it was automatically clipped by the roughness range.

## Fixes Known Issues
**[Ordered list of issues fixed by this PR]**

## Documentation
**[Overview of updates to documentation]**

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
The `texture_clamp_mode` on a imported/exported BSEffectShader is not just the "Texture Clamp Mode" block detail in NifSkope, but also the "Lighting Influence", "Env Map Min LOD" and "Unknown Byte", where each consecutive field 256 higher. Presumably this is an issue with pyffi, but it can be worked around for now.
