### PR TITLE
fix decode for some .nif, and allow external texture to be loaded on embedded .nifs

### DIFF
--- a/io_scene_niftools/modules/nif_import/armature/__init__.py
+++ b/io_scene_niftools/modules/nif_import/armature/__init__.py
@@ -178,7 +178,7 @@ class Armature:
         for bone_name, b_bone in b_armature_obj.data.bones.items():
             n_block = self.name_to_block[bone_name]
             # the property is only available from object mode!
-            block_store.store_longname(b_bone, n_block.name.decode())
+            block_store.store_longname(b_bone, math.safe_decode(n_block.name))
             if NifOp.props.animation:
                 self.transform_anim.import_transforms(n_block, b_armature_obj, bone_name)
 

--- a/io_scene_niftools/modules/nif_import/armature/__init__.py
+++ b/io_scene_niftools/modules/nif_import/armature/__init__.py
@@ -50,6 +50,7 @@ from io_scene_niftools.modules.nif_export.block_registry import block_store as b
 from io_scene_niftools.modules.nif_import.animation.transform import TransformAnimation
 from io_scene_niftools.modules.nif_import.object import Object
 from io_scene_niftools.utils import math
+from io_scene_niftools.utils.blocks import safe_decode
 from io_scene_niftools.utils.logging import NifLog
 from io_scene_niftools.utils.singleton import NifOp, NifData
 
@@ -178,7 +179,7 @@ class Armature:
         for bone_name, b_bone in b_armature_obj.data.bones.items():
             n_block = self.name_to_block[bone_name]
             # the property is only available from object mode!
-            block_store.store_longname(b_bone, math.safe_decode(n_block.name))
+            block_store.store_longname(b_bone, safe_decode(n_block.name))
             if NifOp.props.animation:
                 self.transform_anim.import_transforms(n_block, b_armature_obj, bone_name)
 

--- a/io_scene_niftools/modules/nif_import/object/block_registry.py
+++ b/io_scene_niftools/modules/nif_import/object/block_registry.py
@@ -39,7 +39,7 @@
 
 from io_scene_niftools.utils.logging import NifLog
 
-from io_scene_niftools.utils.math import safe_decode
+from io_scene_niftools.utils.blocks import safe_decode
 
 from io_scene_niftools.utils.consts import BIP_01, BIP01_L, B_L_SUFFIX, BIP01_R, B_R_SUFFIX, NPC_L, NPC_R, NPC_SUFFIX, \
     BRACE_R, B_R_POSTFIX, B_L_POSTFIX, CLOSE_BRACKET, BRACE_L, OPEN_BRACKET

--- a/io_scene_niftools/modules/nif_import/object/block_registry.py
+++ b/io_scene_niftools/modules/nif_import/object/block_registry.py
@@ -39,6 +39,8 @@
 
 from io_scene_niftools.utils.logging import NifLog
 
+from io_scene_niftools.utils.math import safe_decode
+
 from io_scene_niftools.utils.consts import BIP_01, BIP01_L, B_L_SUFFIX, BIP01_R, B_R_SUFFIX, NPC_L, NPC_R, NPC_SUFFIX, \
     BRACE_R, B_R_POSTFIX, B_L_POSTFIX, CLOSE_BRACKET, BRACE_L, OPEN_BRACKET
 
@@ -52,7 +54,7 @@ def get_bone_name_for_blender(name):
     :rtype: :class:`str`
     """
     if isinstance(name, bytes):
-        name = name.decode()
+        name = safe_decode(name)
     if name.startswith(BIP01_L):
         name = BIP_01 + name[8:] + B_L_SUFFIX
     elif name.startswith(BIP01_R):
@@ -90,8 +92,8 @@ class BlockRegistry:
             return ""
 
         NifLog.debug(f"Importing name for {n_block.__class__.__name__} block from {n_block.name}")
-
-        n_name = n_block.name.decode()
+        
+        n_name = safe_decode(n_block.name)
 
         # if name is empty, create something non-empty
         if not n_name:

--- a/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -46,11 +46,6 @@ from io_scene_niftools.utils.logging import NifLog
 from io_scene_niftools.utils.nodes import nodes_iterate
 from io_scene_niftools.utils.consts import TEX_SLOTS
 
-
-# TODO [property][texture] Move IMPORT_EMBEDDED_TEXTURES as a import property
-#temporarly copied in texture until further implimentation.
-IMPORT_EMBEDDED_TEXTURES = False
-
 """Names (ordered by default index) of shader texture slots for Sid Meier's Railroads and similar games."""
 EXTRA_SHADER_TEXTURES = [
     "EnvironmentMapIndex",

--- a/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -48,6 +48,7 @@ from io_scene_niftools.utils.consts import TEX_SLOTS
 
 
 # TODO [property][texture] Move IMPORT_EMBEDDED_TEXTURES as a import property
+#temporarly copied in texture until further implimentation.
 IMPORT_EMBEDDED_TEXTURES = False
 
 """Names (ordered by default index) of shader texture slots for Sid Meier's Railroads and similar games."""

--- a/io_scene_niftools/modules/nif_import/property/texture/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/texture/__init__.py
@@ -36,7 +36,3 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 # ***** END LICENSE BLOCK *****
-
-#TODO: detect if the texture is embeded or prompt the user to decide if the texture is embeded or not
-#setting to True is based on incomplete pyffi implimentation of save_dds
-IMPORT_EMBEDDED_TEXTURES = False

--- a/io_scene_niftools/modules/nif_import/property/texture/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/texture/__init__.py
@@ -36,3 +36,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 # ***** END LICENSE BLOCK *****
+
+#TODO: detect if the texture is embeded or prompt the user to decide if the texture is embeded or not
+#setting to True is based on incomplete pyffi implimentation of save_dds
+IMPORT_EMBEDDED_TEXTURES = False

--- a/io_scene_niftools/modules/nif_import/property/texture/loader.py
+++ b/io_scene_niftools/modules/nif_import/property/texture/loader.py
@@ -73,7 +73,7 @@ class TextureLoader:
         # if the source block is not linked then return None
         if not source:
             return None
-
+        NifLog.warn(f"Import embedded texture skipped, defaulting to import external texture")#IMPORT_EMBEDDED_TEXTURES is currently a constant
         if isinstance(source, NifFormat.NiSourceTexture) and not source.use_external and texture.IMPORT_EMBEDDED_TEXTURES:
             return self.import_embedded_texture_source(source)
         else:

--- a/io_scene_niftools/modules/nif_import/property/texture/loader.py
+++ b/io_scene_niftools/modules/nif_import/property/texture/loader.py
@@ -42,11 +42,134 @@ import operator
 import os.path
 
 import bpy
+from pyffi.formats.dds import DdsFormat
 from pyffi.formats.nif import NifFormat
 
 from io_scene_niftools.modules.nif_import.property import texture
 from io_scene_niftools.utils.singleton import NifOp
 from io_scene_niftools.utils.logging import NifLog
+
+
+# TODO once the save_dds PR code is merged into pyffi this section can be deleted.
+# This section replaces pyffi methods to impliment functionality immediately.
+#################
+def get_pixeldata_stream_overide(self):
+    if isinstance(self, NifFormat.NiPersistentSrcTextureRendererData):
+        return ''.join(
+            ''.join([chr(x) for x in tex])
+            for tex in self.pixel_data)
+    elif isinstance(self, NifFormat.NiPixelData):
+        if self.pixel_data:
+            # used in older nif versions
+            return bytearray().join(
+                bytearray().join([bytearray([x]) for x in tex])
+                for tex in self.pixel_data)
+        else:
+            # used in newer nif versions
+            return ''.join(self.pixel_data_matrix)
+    else:
+        raise ValueError(
+            "cannot retrieve pixel data when saving pixel format %i as DDS")
+def save_as_dds_override(self, stream):
+    data = DdsFormat.Data()
+    header = data.header
+    pixeldata = data.pixeldata
+
+    # create header, depending on the format
+    if self.pixel_format in (NifFormat.PixelFormat.PX_FMT_RGB8,
+                             NifFormat.PixelFormat.PX_FMT_RGBA8):
+        # uncompressed RGB(A)
+        header.flags.caps = 1
+        header.flags.height = 1
+        header.flags.width = 1
+        header.flags.pixel_format = 1
+        header.flags.mipmap_count = 1
+        header.flags.linear_size = 1
+        header.height = self.mipmaps[0].height
+        header.width = self.mipmaps[0].width
+        header.linear_size = len(self.pixel_data)
+        header.mipmap_count = len(self.mipmaps)
+        header.pixel_format.flags.rgb = 1
+        header.pixel_format.bit_count = self.bits_per_pixel
+        if not self.channels:
+            header.pixel_format.r_mask = self.red_mask
+            header.pixel_format.g_mask = self.green_mask
+            header.pixel_format.b_mask = self.blue_mask
+            header.pixel_format.a_mask = self.alpha_mask
+        else:
+            bit_pos = 0
+            for i, channel in enumerate(self.channels):
+                mask = (2 ** channel.bits_per_channel - 1) << bit_pos
+                if channel.type == NifFormat.ChannelType.CHNL_RED:
+                    header.pixel_format.r_mask = mask
+                elif channel.type == NifFormat.ChannelType.CHNL_GREEN:
+                    header.pixel_format.g_mask = mask
+                elif channel.type == NifFormat.ChannelType.CHNL_BLUE:
+                    header.pixel_format.b_mask = mask
+                elif channel.type == NifFormat.ChannelType.CHNL_ALPHA:
+                    header.pixel_format.a_mask = mask
+                bit_pos += channel.bits_per_channel
+        header.caps_1.complex = 1
+        header.caps_1.texture = 1
+        header.caps_1.mipmap = 1
+        pixeldata.set_value(self.__get_pixeldata_stream())
+    elif self.pixel_format == NifFormat.PixelFormat.PX_FMT_DXT1:
+        # format used in Megami Tensei: Imagine and Bully SE
+        header.flags.caps = 1
+        header.flags.height = 1
+        header.flags.width = 1
+        header.flags.pixel_format = 1
+        header.flags.mipmap_count = 1
+        header.flags.linear_size = 0
+        header.height = self.mipmaps[0].height
+        header.width = self.mipmaps[0].width
+        header.linear_size = 0
+        header.mipmap_count = len(self.mipmaps)
+        header.pixel_format.flags.four_c_c = 1
+        header.pixel_format.four_c_c = DdsFormat.FourCC.DXT1
+        header.pixel_format.bit_count = 0
+        header.pixel_format.r_mask = 0
+        header.pixel_format.g_mask = 0
+        header.pixel_format.b_mask = 0
+        header.pixel_format.a_mask = 0
+        header.caps_1.complex = 1
+        header.caps_1.texture = 1
+        header.caps_1.mipmap = 1
+        pixeldata.set_value(self.__get_pixeldata_stream())
+    elif self.pixel_format in (NifFormat.PixelFormat.PX_FMT_DXT5,
+                               NifFormat.PixelFormat.PX_FMT_DXT5_ALT):
+        # format used in Megami Tensei: Imagine
+        header.flags.caps = 1
+        header.flags.height = 1
+        header.flags.width = 1
+        header.flags.pixel_format = 1
+        header.flags.mipmap_count = 1
+        header.flags.linear_size = 0
+        header.height = self.mipmaps[0].height
+        header.width = self.mipmaps[0].width
+        header.linear_size = 0
+        header.mipmap_count = len(self.mipmaps)
+        header.pixel_format.flags.four_c_c = 1
+        header.pixel_format.four_c_c = DdsFormat.FourCC.DXT5
+        header.pixel_format.bit_count = 0
+        header.pixel_format.r_mask = 0
+        header.pixel_format.g_mask = 0
+        header.pixel_format.b_mask = 0
+        header.pixel_format.a_mask = 0
+        header.caps_1.complex = 1
+        header.caps_1.texture = 1
+        header.caps_1.mipmap = 1
+        pixeldata.set_value(self.__get_pixeldata_stream())
+    else:
+        raise ValueError(
+            "cannot save pixel format %i as DDS" % self.pixel_format)
+
+    data.write(stream)
+
+
+NifFormat.ATextureRenderData.__get_pixeldata_stream = get_pixeldata_stream_overide
+NifFormat.ATextureRenderData.save_as_dds = save_as_dds_override
+#################
 
 
 class TextureLoader:
@@ -73,8 +196,8 @@ class TextureLoader:
         # if the source block is not linked then return None
         if not source:
             return None
-        NifLog.warn(f"Import embedded texture skipped, defaulting to import external texture")#IMPORT_EMBEDDED_TEXTURES is currently a constant
-        if isinstance(source, NifFormat.NiSourceTexture) and not source.use_external and texture.IMPORT_EMBEDDED_TEXTURES:
+
+        if isinstance(source, NifFormat.NiSourceTexture) and not source.use_external and NifOp.props.use_embedded_texture:
             return self.import_embedded_texture_source(source)
         else:
             return self.import_external_source(source)

--- a/io_scene_niftools/nif_import.py
+++ b/io_scene_niftools/nif_import.py
@@ -211,7 +211,7 @@ class NifImport(NifCommon):
         if not n_block:
             return None
 
-        NifLog.info(f"Importing data for block '{n_block.name.decode()}'")
+        NifLog.info(f"Importing data for block '{math.safe_decode(n_block.name)}'")
         if isinstance(n_block, NifFormat.NiTriBasedGeom) and NifOp.props.process != "SKELETON_ONLY":
             return self.objecthelper.import_geometry_object(b_armature, n_block)
 

--- a/io_scene_niftools/nif_import.py
+++ b/io_scene_niftools/nif_import.py
@@ -60,6 +60,7 @@ from io_scene_niftools.modules.nif_import.property.object import ObjectProperty
 
 from io_scene_niftools.nif_common import NifCommon
 from io_scene_niftools.utils import math
+from io_scene_niftools.utils.blocks import safe_decode
 from io_scene_niftools.utils.singleton import NifOp, NifData
 from io_scene_niftools.utils.logging import NifLog, NifError
 
@@ -211,7 +212,7 @@ class NifImport(NifCommon):
         if not n_block:
             return None
 
-        NifLog.info(f"Importing data for block '{math.safe_decode(n_block.name)}'")
+        NifLog.info(f"Importing data for block '{safe_decode(n_block.name)}'")
         if isinstance(n_block, NifFormat.NiTriBasedGeom) and NifOp.props.process != "SKELETON_ONLY":
             return self.objecthelper.import_geometry_object(b_armature, n_block)
 

--- a/io_scene_niftools/operators/nif_import_op.py
+++ b/io_scene_niftools/operators/nif_import_op.py
@@ -111,6 +111,11 @@ class NifImportOperator(Operator, ImportHelper, CommonScale, CommonDevOperator, 
         name="Combine Vertices",
         description="Merge vertices that have identical location and normal values.",
         default=False)
+    
+    use_embedded_texture: bpy.props.BoolProperty(
+        name="Use Embedded Texture",
+        description="Loads texture embedded in .nif",
+        default=False)
 
     def draw(self, context):
         pass

--- a/io_scene_niftools/ui/operators/nif_import.py
+++ b/io_scene_niftools/ui/operators/nif_import.py
@@ -94,7 +94,7 @@ class OperatorImportTransformPanel(OperatorSetting, Panel):
 
 
 class OperatorImportGeometryPanel(OperatorSetting, Panel):
-    bl_label = "Transform"
+    bl_label = "Geometry"
     bl_idname = "NIFTOOLS_PT_import_operator_geometry"
 
     @classmethod
@@ -114,6 +114,28 @@ class OperatorImportGeometryPanel(OperatorSetting, Panel):
 
         layout.prop(operator, "combine_vertices")
         layout.prop(operator, "use_custom_normals")
+
+
+class OperatorImportTexturePanel(OperatorSetting, Panel):
+    bl_label = "Texture"
+    bl_idname = "NIFTOOLS_PT_import_operator_texture"
+
+    @classmethod
+    def poll(cls, context):
+        sfile = context.space_data
+        operator = sfile.active_operator
+
+        return operator.bl_idname == "IMPORT_SCENE_OT_nif"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation.
+
+        sfile = context.space_data
+        operator = sfile.active_operator
+
+        layout.prop(operator, "use_embedded_texture")
 
 
 class OperatorImportArmaturePanel(OperatorSetting, Panel):
@@ -170,6 +192,7 @@ classes = [
     OperatorImportIncludePanel,
     OperatorImportTransformPanel,
     OperatorImportGeometryPanel,
+    OperatorImportTexturePanel,
     OperatorImportArmaturePanel,
     OperatorImportAnimationPanel
 ]

--- a/io_scene_niftools/utils/blocks.py
+++ b/io_scene_niftools/utils/blocks.py
@@ -1,0 +1,7 @@
+""" Nif Utilities, stores common code that is used across the code base"""
+
+def safe_decode(b: bytes) -> str:
+    try:
+        return b.decode()
+    except UnicodeDecodeError:
+        return b.decode("shift-jis", errors="surrogateescape")

--- a/io_scene_niftools/utils/math.py
+++ b/io_scene_niftools/utils/math.py
@@ -227,9 +227,3 @@ def mathutils_to_nifformat_matrix(b_matrix):
     n_matrix = NifFormat.Matrix44()
     n_matrix.set_rows(*b_matrix.transposed())
     return n_matrix
-
-def safe_decode(b: bytes) -> str:
-    try:
-        return b.decode()
-    except UnicodeDecodeError:
-        return b.decode("shift-jis", errors="surrogateescape")

--- a/io_scene_niftools/utils/math.py
+++ b/io_scene_niftools/utils/math.py
@@ -227,3 +227,9 @@ def mathutils_to_nifformat_matrix(b_matrix):
     n_matrix = NifFormat.Matrix44()
     n_matrix.set_rows(*b_matrix.transposed())
     return n_matrix
+
+def safe_decode(b: bytes) -> str:
+    try:
+        return b.decode()
+    except UnicodeDecodeError:
+        return b.decode("shift-jis", errors="surrogateescape")


### PR DESCRIPTION
Added safe_decode function to math utils and changed decode function only where it caused crash. Decode error can still occur where safe decode is not used. Also added some support for embedded .nif textures to be loaded externally

@niftools/blender-niftools-addon-reviewer 

# Overview
**[Fixes a decode bug]**

##  Detailed Description
**[addded safe_decode to utils.math, replaced the decode functions causing crash with safe_decode. The actual encoding of the file is unknown, I tested a list of potential encodings and choose the most accurate, but it is still not correct. Fixed definition error of IMPORT_EMBEDDED_TEXTURES]**

## Fixes Known Issues
**[#441, #421 partially, #443 partially]**

## Documentation
**[None]**

## Testing
**[was able to load models without Decode error, but results in new errors potentially unrelated,  was able to load embedded .nifs with external textures]**

### Manual
**[Imported a .nif and decode error wasn't generated]**

### Automated
**[None]**

## Additional Information
**[The next error is due to IMPORT_EMBEDDED_TEXTURES not being implemented.(fixed). This PR was edited to add another PR]**
