### PR TITLE
Several small fixes

### DIFF
--- a/io_scene_niftools/__init__.py
+++ b/io_scene_niftools/__init__.py
@@ -119,5 +119,5 @@ def configure_autoupdater():
     addon_updater_ops.updater.remove_pre_update_patterns = ["*.py", "*.pyc", "*.xml", "*.exe", "*.rst", "VERSION", "*.xsd"]
     addon_updater_ops.updater.user = "niftools"
     addon_updater_ops.updater.repo = "blender_niftools_addon"
-    addon_updater_ops.updater.website = "https://github.com/niftools/blender-niftools-addon/"
+    addon_updater_ops.updater.website = "https://github.com/niftools/blender_niftools_addon/"
     addon_updater_ops.updater.version_min_update = (0, 0, 4)

--- a/io_scene_niftools/addon_updater_ops.py
+++ b/io_scene_niftools/addon_updater_ops.py
@@ -1354,7 +1354,7 @@ def register(bl_info):
     # updater.addon = # define at top of module, MUST be done first
 
     # Website for manual addon download, optional but recommended to set
-    updater.website = "https://github.com/niftools/blender-niftools-addon/"
+    updater.website = "https://github.com/niftools/blender_niftools_addon/"
 
     # Addon subfolder path
     # "sample/path/to/addon"

--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -532,8 +532,7 @@ class Mesh:
         for i, bone in enumerate(skininst.bones):
             bone_name = block_store.block_to_obj[bone].name
             pose_bone = b_obj_armature.pose.bones[bone_name]
-            n_bind = NifFormat.Matrix44()
-            n_bind.set_rows(*math.blender_bind_to_nif_bind(pose_bone.matrix).transposed())
+            n_bine = math.mathutils_to_nifformat_matrix(*math.blender_bind_to_nif_bind(pose_bone.matrix))
             # todo [armature] figure out the correct transform that works universally
             # inverse skin bind in nif armature space, relative to root / geom??
             skindata.bone_list[i].set_transform((n_bind * geomtransform).get_inverse(fast=False))

--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -404,7 +404,7 @@ class Mesh:
 
                         for b_vert in b_mesh.vertices:
                             if len(b_vert.groups) == 0:  # check vert has weight_groups
-                                unweighted_vertices.append(b_vert)
+                                unweighted_vertices.append(b_vert.index)
                                 continue
 
                             for g in b_vert.groups:
@@ -422,7 +422,7 @@ class Mesh:
                             else:
                                 vert_norm[v[0]] = v[1]
 
-                    self.select_unweighted_vertices(unweighted_vertices)
+                    self.select_unweighted_vertices(b_obj, unweighted_vertices)
 
                     # for each bone, first we get the bone block then we get the vertex weights and then we add it to the NiSkinData
                     # note: allocate memory for faster performance
@@ -624,21 +624,26 @@ class Mesh:
                     trishape.flags = 0x0005  # use triangles as bounding box + hide
 
     # todo [mesh] join code paths for those two?
-    def select_unweighted_vertices(self, unweighted_vertices):
+    def select_unweighted_vertices(self, b_obj, unweighted_vertices):
         # vertices must be assigned at least one vertex group lets be nice and display them for the user
         if len(unweighted_vertices) > 0:
             for b_scene_obj in bpy.context.scene.objects:
                 b_scene_obj.select_set(False)
 
-            b_obj = bpy.context.view_layer.objects.active
-            b_obj.select_set(True)
+            bpy.context.view_layer.objects.active = b_obj
 
-            # switch to edit mode and raise exception
+            # switch to edit mode to deselect everything in the mesh (not missing vertices or edges)
             bpy.ops.object.mode_set(mode='EDIT', toggle=False)
-            # clear all currently selected vertices
+            bpy.context.tool_settings.mesh_select_mode = (True, False, False)
             bpy.ops.mesh.select_all(action='DESELECT')
-            # select unweighted vertices
-            bpy.ops.mesh.select_ungrouped(extend=False)
+
+            # select unweighted vertices - switch back to object mode to make per-vertex selection
+            bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
+            for vert_index in unweighted_vertices:
+                b_obj.data.vertices[vert_index].select = True
+
+            # switch back to edit mode to make the selection visible and raise exception
+            bpy.ops.object.mode_set(mode='EDIT', toggle=False)
 
             raise NifError("Cannot export mesh with unweighted vertices. "
                            "The unweighted vertices have been selected in the mesh so they can easily be identified.")

--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -532,7 +532,7 @@ class Mesh:
         for i, bone in enumerate(skininst.bones):
             bone_name = block_store.block_to_obj[bone].name
             pose_bone = b_obj_armature.pose.bones[bone_name]
-            n_bine = math.mathutils_to_nifformat_matrix(*math.blender_bind_to_nif_bind(pose_bone.matrix))
+            n_bind = math.mathutils_to_nifformat_matrix(math.blender_bind_to_nif_bind(pose_bone.matrix))
             # todo [armature] figure out the correct transform that works universally
             # inverse skin bind in nif armature space, relative to root / geom??
             skindata.bone_list[i].set_transform((n_bind * geomtransform).get_inverse(fast=False))

--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -117,7 +117,7 @@ class Mesh:
             mesh_hasnormals = False
             if b_mat is not None:
                 mesh_hasnormals = True  # for proper lighting
-                if (game == 'SKYRIM') and (b_mat.niftools_shader.bslsp_shaderobjtype in ('Skin Tint', 'Face Tint')):
+                if (game == 'SKYRIM') and b_mat.niftools_shader.slsf_1_model_space_normals:
                     mesh_hasnormals = False  # for proper lighting
 
             # create a trishape block

--- a/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -329,8 +329,8 @@ class NodesWrapper:
             group_links.new(combine_node.inputs[1], invert_node.outputs[0])
             group_links.new(combine_node.inputs[2], separate_node.outputs[2])
             # link the converting nodes to the input/output
-            group_links.new(separate_node.inputs[0], input_node.outputs['Input'])
-            group_links.new(output_node.inputs['Output'], combine_node.outputs[0])
+            group_links.new(separate_node.inputs[0], input_node.outputs[0])
+            group_links.new(output_node.inputs[0], combine_node.outputs[0])
             nodes_iterate(node_group, output_node)
         # add the group node to the main node tree and link it
         group_node = nodes.new('ShaderNodeGroup')

--- a/io_scene_niftools/operators/nif_export_op.py
+++ b/io_scene_niftools/operators/nif_export_op.py
@@ -107,7 +107,7 @@ class NifExportOperator(Operator, ExportHelper, CommonDevOperator, CommonNif, Co
     max_bones_per_partition: bpy.props.IntProperty(
         name="Max Partition Bones",
         description="Maximum number of bones per skin partition",
-        default=18, min=4, max=63)
+        default=18, min=4, max=65535)
 
     # Maximum number of bones per vertex in skin partitions.
     max_bones_per_vertex: bpy.props.IntProperty(


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
1. Addition of vertex normals/tangents/bitangents now depends on whether the 'model space normals' flag is enabled, rather than the shader type.
2. Changed the limit for "Max Partition Bones" on export to the ushort limit (63 before), since Skyrim LE apparently has unlimited bones.
3. Added single use of `math.mathutils_to_nifformat_matrix` to replace existing equivalent code.
4. Corrected the backup links for the auto updater to use underscores instead of dashes (would result in 'page not found'.
5. Changed shader node socket linking that used strings to use integers, for 2.8 compatibility.
6. Fixed unweighted vertex selection for issue #490 and #491.

##  Detailed Description
Since these are very small updates, most are covered by the short description.

## Fixes Known Issues
1. #490 
2. #491 

## Documentation
**[Overview of updates to documentation]**

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
