### PR TITLE
Slight fix for triangle assignment to bodypart on partition import

### DIFF
--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -460,6 +460,24 @@ class Mesh:
 
                     if NifData.data.version >= 0x04020100 and NifOp.props.skin_partition:
                         NifLog.info("Creating skin partition")
+
+                        # warn on bad config settings
+                        if game == 'OBLIVION':
+                            if NifOp.props.pad_bones:
+                                NifLog.warn("Using padbones on Oblivion export. Disable the pad bones option to get higher quality skin partitions.")
+                        if game in ('OBLIVION', 'FALLOUT_3'):
+                            if NifOp.props.max_bones_per_partition < 18:
+                                NifLog.warn("Using less than 18 bones per partition on Oblivion/Fallout 3 export."
+                                            "Set it to 18 to get higher quality skin partitions.")
+                            elif NifOp.props.max_bones_per_partition > 18:
+                                NifLog.warn("Using more than 18 bones per partition on Oblivion/Fallout 3 export."
+                                            "This may cause issues in-game.")
+                        if game == 'SKYRIM':
+                            if NifOp.props.max_bones_per_partition < 24:
+                                NifLog.warn("Using less than 24 bones per partition on Skyrim export."
+                                            "Set it to 24 to get higher quality skin partitions.")
+                        # Skyrim Special Edition has a limit of 80 bones per partition, but export is not yet supported
+
                         part_order = [getattr(NifFormat.BSDismemberBodyPartType, face_map.name, None) for face_map in b_obj.face_maps]
                         part_order = [body_part for body_part in part_order if body_part is not None]
                         # override pyffi trishape.update_skin_partition with custom one (that allows ordering)
@@ -475,18 +493,6 @@ class Mesh:
                             maximize_bone_sharing=(game in ('FALLOUT_3', 'SKYRIM')),
                             part_sort_order=part_order)
 
-                        # warn on bad config settings
-                        if game == 'OBLIVION':
-                            if NifOp.props.pad_bones:
-                                NifLog.warn("Using padbones on Oblivion export. Disable the pad bones option to get higher quality skin partitions.")
-                        if game in ('OBLIVION', 'FALLOUT_3'):
-                            if NifOp.props.max_bones_per_partition < 18:
-                                NifLog.warn("Using less than 18 bones per partition on Oblivion/Fallout 3 export."
-                                            "Set it to 18 to get higher quality skin partitions.")
-                        if game == 'SKYRIM':
-                            if NifOp.props.max_bones_per_partition < 24:
-                                NifLog.warn("Using less than 24 bones per partition on Skyrim export."
-                                            "Set it to 24 to get higher quality skin partitions.")
                         if lostweight > NifOp.props.epsilon:
                             NifLog.warn(f"Lost {lostweight:f} in vertex weights while creating a skin partition for Blender object '{b_obj.name}' (nif block '{trishape.name}')")
 

--- a/io_scene_niftools/modules/nif_import/geometry/vertex/groups.py
+++ b/io_scene_niftools/modules/nif_import/geometry/vertex/groups.py
@@ -164,8 +164,14 @@ class VertexGroup:
                                 v_group.add([vert], w, 'REPLACE')
 
         # import body parts as face maps
-        # get faces (triangles) as map of tuples to index
-        tri_map = {frozenset(polygon.vertices): polygon.index for polygon in b_obj.data.polygons}
+        # get faces (triangles) as map of unordered vertices to list of indices
+        tri_map = {}
+        for polygon in b_obj.data.polygons:
+            vertices = frozenset(polygon.vertices)
+            if vertices in tri_map:
+                tri_map[vertices].append(polygon.index)
+            else:
+                tri_map[vertices] = [polygon.index]
         if isinstance(skininst, NifFormat.BSDismemberSkinInstance):
             skinpart = ni_block.get_skin_partition()
             for bodypart, skinpartblock in zip(skininst.partitions, skinpart.skin_partition_blocks):
@@ -178,4 +184,5 @@ class VertexGroup:
                     f_group = b_obj.face_maps.new(name=group_name)
 
                 # add the triangles to the face map
-                f_group.add([tri_map[frozenset(vertices)] for vertices in skinpartblock.get_mapped_triangles()])
+                for vertices in skinpartblock.get_mapped_triangles():
+                    f_group.add(tri_map[frozenset(vertices)])


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
1. Added warning for too many bones per partition (since some games will crash with that, I think?) and pulled up the check for this.
2. Fix for issue #496 , by allowing for multiple triangles to map from the same vertices when doing the map from partition triangles to the main NiTriShape.

##  Detailed Description
1. Self-explanatory.
2. Causing the issue was the fact that there were two triangles using the same vertices for this particular mesh, so on import those vertices only mapped to the first triangle. The code has now been changed such that the vertices map to a list of all triangles (in the overwhelming majority of cases just 1) using those vertices. However, that does mean that all triangles sharing the same vertices will end up in the same partition on import, which is not necessary (though always the case in vanilla meshes, as far as I know). Also, it is possible for a triangle to be defined in the main NiTriShape, but not in any of the partitions (again, this does not seem to happen). A true fix would mean that we import skinned shapes from the triangle data in the NiSkinPartition instead of relying on the triangles in the main NiTriShape, though of course this is a lot of work. It will be necessary for SSE meshes when we support those, because there, triangles are _only_ defined in the NiSkinPartition.

## Fixes Known Issues
1. #496

## Documentation
**[Overview of updates to documentation]**

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
