### PR TITLE
Two small fixes including #499

### DIFF
--- a/io_scene_niftools/modules/nif_export/collision/havok.py
+++ b/io_scene_niftools/modules/nif_export/collision/havok.py
@@ -173,7 +173,7 @@ class BhkCollision(Collision):
         n_r_body.restitution = b_r_body.restitution
         n_r_body.max_linear_velocity = b_obj.nifcollision.max_linear_velocity
         n_r_body.max_angular_velocity = b_obj.nifcollision.max_angular_velocity
-        n_r_body.penetration_depth = b_obj.collision.permeability
+        n_r_body.penetration_depth = b_obj.nifcollision.penetration_depth
         n_r_body.motion_system = b_obj.nifcollision.motion_system
         n_r_body.deactivator_type = b_obj.nifcollision.deactivator_type
         n_r_body.solver_deactivation = b_obj.nifcollision.solver_deactivation

--- a/io_scene_niftools/modules/nif_import/collision/havok.py
+++ b/io_scene_niftools/modules/nif_import/collision/havok.py
@@ -269,7 +269,11 @@ class BhkCollision(Collision):
         # find vertices (and fix scale)
         scaled_verts = [(self.HAVOK_SCALE * n_vert.x, self.HAVOK_SCALE * n_vert.y, self.HAVOK_SCALE * n_vert.z)
                         for n_vert in bhk_shape.vertices]
-        verts, faces = qhull3d(scaled_verts)
+        if scaled_verts:
+            verts, faces = qhull3d(scaled_verts)
+        else:
+            verts = []
+            faces = []
 
         b_obj = Object.mesh_from_data("convexpoly", verts, faces)
         radius = bhk_shape.radius * self.HAVOK_SCALE

--- a/io_scene_niftools/modules/nif_import/collision/havok.py
+++ b/io_scene_niftools/modules/nif_import/collision/havok.py
@@ -197,7 +197,7 @@ class BhkCollision(Collision):
             b_r_body.deactivate_angular_velocity = mathutils.Vector([ang_vel.w, ang_vel.x, ang_vel.y, ang_vel.z]).magnitude
 
             # Custom Niftools properties
-            b_col_obj.collision.permeability = bhkshape.penetration_depth
+            b_col_obj.nifcollision.penetration_depth = bhkshape.penetration_depth
             b_col_obj.nifcollision.deactivator_type = NifFormat.DeactivatorType._enumkeys[bhkshape.deactivator_type]
             b_col_obj.nifcollision.solver_deactivation = NifFormat.SolverDeactivation._enumkeys[bhkshape.solver_deactivation]
             b_col_obj.nifcollision.max_linear_velocity = bhkshape.max_linear_velocity

--- a/io_scene_niftools/properties/collision.py
+++ b/io_scene_niftools/properties/collision.py
@@ -82,6 +82,12 @@ class CollisionProperty(PropertyGroup):
         items=game_specific_col_layer_items,
     )
 
+    penetration_depth: FloatProperty(
+        name='Penetration Depth',
+        description='The maximum allowed penetration for this object.',
+        default=0.15
+    )
+
     deactivator_type: EnumProperty(
         name='Deactivator Type',
         description='Motion deactivation setting',


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
Fix for importing an empty (convex) collision shape and fix for issue #499 by moving it to a setting rather than using the collision physics property.

##  Detailed Description
There was previously an error when importing a convex collision without vertices - probably wasn't noticed before because this didn't happen often. This was due to an issue with qhull when feeding empty vertices. Now that qhull step is simply skipped if there are no vertices.
The fix for #499 is perhaps a bit simple, and there might be more elegant solutions, but this was made quickly for someone who wanted to use the plugin in Blender 3.

## Fixes Known Issues
1. #499 

## Documentation
**[Overview of updates to documentation]**

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
