### PR TITLE
Use "@" instead of "*" for matrix multiplication

### DIFF
--- a/io_scene_niftools/modules/nif_export/collision/havok.py
+++ b/io_scene_niftools/modules/nif_export/collision/havok.py
@@ -522,14 +522,14 @@ class BhkCollision(Collision):
         transform = math.get_object_bind(b_obj)
         rotation = transform.decompose()[1]
 
-        vertices = [vert.co * transform for vert in b_mesh.vertices]
+        vertices = [vert.co @ transform for vert in b_mesh.vertices]
         triangles = []
         normals = []
         for face in b_mesh.polygons:
             if len(face.vertices) < 3:
                 continue  # ignore degenerate polygons
             triangles.append([face.vertices[i] for i in (0, 1, 2)])
-            normals.append(rotation * face.normal)
+            normals.append(rotation @ face.normal)
             if len(face.vertices) == 4:
                 triangles.append([face.vertices[i] for i in (0, 2, 3)])
                 normals.append(rotation * face.normal)


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
Replaces two instances of using "*" for matrix multiplication with "@".

## Fixes Known Issues
Fixes the "TypeError: Element-wise multiplication: not supported between 'Vector' and 'Matrix' types" error mentioned in https://github.com/niftools/blender_niftools_addon/issues/453.

## Documentation
From https://wiki.blender.org/wiki/Reference/Release_Notes/2.80/Python_API

> Matrix multiplication previously used *, scripts should now use @ for multiplication (per [PEP 465](https://www.python.org/dev/peps/pep-0465/)). This applies to:
> 
> Vector * Vector
> Quaternion * Vector
> Matrix * Vector
> Vector * Matrix
> Matrix * Matrix
> Note: In the future * will be used for element-wise multiplication

## Testing
Try to export a .nif file imported from Oblivion into Blender (tested with version 3.1.2) using the niftools addon. 

## Additional Information
This fixes the above mentioned error, but other errors will then be reached and exporting will still fail because of them. See https://github.com/niftools/blender_niftools_addon/issues/453.

This PR only fixes these two lines, which raised the above error when I tried to export a .nif file imported from Oblivion. There may be other instances of matrix multiplication in the code that also need to be fixed.