### PR TITLE
Update version number

### DIFF
--- a/io_scene_niftools/__init__.py
+++ b/io_scene_niftools/__init__.py
@@ -49,7 +49,7 @@ bl_info = {
     "description": "Import and export files in the NetImmerse/Gamebryo formats (.nif, .kf, .egm)",
     "author": "Niftools team",
     "blender": (2, 82, 0),
-    "version": (0, 0, 13),  # can't read from VERSION, blender wants it hardcoded
+    "version": (0, 0, 15),  # can't read from VERSION, blender wants it hardcoded
     "api": 39257,
     "location": "File > Import-Export",
     "warning": "Generally stable port of the Niftool's Blender NifScripts, many improvements, still work in progress",


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
Update the version number to 0.0.15

## Fixes Known Issues
This will stop Blender from trying to update when the add-on is already up-to-date. This is currently an issue with 0.0.14. Blender will offer to update because this file still says it is version 0.0.13. If you click to update, the update fails and the add-on becomes unusable until you re-install it.

The idea of this PR is to go ahead and up the version for the develop branch to catch this problem before it can happen again with the next release.

## Testing
Check whether Blender thinks the add-on is up-to-date or not.

## Additional Information
Screen from Blender with the current version of this add-on (0.0.14). It's incorrectly detected as 0.0.13.

![Update](https://user-images.githubusercontent.com/19624336/170486122-50bbe65f-5dff-4cde-b203-b3ca441daebf.png)

