### PR TITLE
Fix missed hard coded version string in the __init__.py file

### DIFF
--- a/io_scene_niftools/__init__.py
+++ b/io_scene_niftools/__init__.py
@@ -49,7 +49,7 @@ bl_info = {
     "description": "Import and export files in the NetImmerse/Gamebryo formats (.nif, .kf, .egm)",
     "author": "Niftools team",
     "blender": (2, 82, 0),
-    "version": (0, 0, 13),  # can't read from VERSION, blender wants it hardcoded
+    "version": (0, 0, 14),  # can't read from VERSION, blender wants it hardcoded
     "api": 39257,
     "location": "File > Import-Export",
     "warning": "Generally stable port of the Niftool's Blender NifScripts, many improvements, still work in progress",


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
**[Overview of the content of the pull request]**
Fix incorrect version string

##  Detailed Description
**[List of functional updates]**
Correct the version to (0, 0, 14) in the blender addon tuple.
Only affect auto-updater

## Fixes Known Issues
**[Ordered list of issues fixed by this PR]**

## Documentation
**[Overview of updates to documentation]**

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
