### PR TITLE
int cast in add_dummy_markers to comply with blender python 3.1+

### DIFF
--- a/io_scene_niftools/modules/nif_export/animation/__init__.py
+++ b/io_scene_niftools/modules/nif_export/animation/__init__.py
@@ -201,4 +201,4 @@ class Animation(ABC):
             NifLog.info("Defining default action pose markers.")
             for frame, text in zip(b_action.frame_range, ("Idle: Start/Idle: Loop Start", "Idle: Loop Stop/Idle: Stop")):
                 marker = b_action.pose_markers.new(text)
-                marker.frame = frame
+                marker.frame = int(frame)

--- a/io_scene_niftools/modules/nif_import/animation/__init__.py
+++ b/io_scene_niftools/modules/nif_import/animation/__init__.py
@@ -58,7 +58,7 @@ class Animation:
     @staticmethod
     def get_controller_data(ctrl):
         """Return data for ctrl, look in interpolator (for newer games) or directly on ctrl"""
-        if ctrl.interpolator:
+        if hasattr(ctrl, 'interpolator') and ctrl.interpolator:
             data = ctrl.interpolator.data
         else:
             data = ctrl.data


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
blenders python had some changes from 3.1+ that affect scripting, from docs:
https://wiki.blender.org/wiki/Reference/Release_Notes/3.1/Python_API
"Python 3.10 no longer implicitly converts floats to int's ([issue linked](https://bugs.python.org/issue37999)). This means functions that previously accepted float typed values will raise a type error.
Floating point arguments must now be explicitly converted to integers"

This error is encountered in add_dummy_markers in nif_export/animation/init.py

![float-to-int_niftools](https://user-images.githubusercontent.com/28895915/173386319-9a82329f-dab6-4fcb-8251-67f4240ca59c.png)

A simple int cast resolves this - don't know if similar issues exists in other parts of the code. Should be harmless?

##  Detailed Description
**[List of functional updates]**

## Fixes Known Issues
None afaik

## Documentation
**[Overview of updates to documentation]**

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
