### PR TITLE
Allow setting armature axis manually

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (blender_niftools_addon)" project-jdk-type="Python SDK" />
   <component name="PythonCompatibilityInspectionAdvertiser">
     <option name="version" value="3" />
   </component>

--- a/io_scene_niftools/modules/nif_import/armature/__init__.py
+++ b/io_scene_niftools/modules/nif_import/armature/__init__.py
@@ -182,7 +182,7 @@ class Armature:
         b_armature_data.display_type = 'STICK'
 
         # use heuristics to determine a suitable orientation, if requested
-        if NifOp.props.guess_armature_orientation:
+        if not NifOp.props.override_armature_orientation:
             forward, up = self.guess_orientation(n_armature)
         else:
             forward, up = (NifOp.props.armature_axis_forward, NifOp.props.armature_axis_up)

--- a/io_scene_niftools/modules/nif_import/armature/__init__.py
+++ b/io_scene_niftools/modules/nif_import/armature/__init__.py
@@ -40,6 +40,7 @@
 import os
 
 import bpy
+from bpy_extras.io_utils import orientation_helper
 import mathutils
 
 from pyffi.formats.nif import NifFormat
@@ -185,7 +186,7 @@ class Armature:
         if not NifOp.props.override_armature_orientation:
             forward, up = self.guess_orientation(n_armature)
         else:
-            forward, up = (NifOp.props.armature_axis_forward, NifOp.props.armature_axis_up)
+            forward, up = (NifOp.props.axis_forward, NifOp.props.axis_up)
         # pass them to the matrix utility
         math.set_bone_orientation(forward, up)
         # store axis orientation for export

--- a/io_scene_niftools/modules/nif_import/armature/__init__.py
+++ b/io_scene_niftools/modules/nif_import/armature/__init__.py
@@ -181,8 +181,11 @@ class Armature:
         b_armature_data = bpy.data.armatures.new(armature_name)
         b_armature_data.display_type = 'STICK'
 
-        # use heuristics to determine a suitable orientation
-        forward, up = self.guess_orientation(n_armature)
+        # use heuristics to determine a suitable orientation, if requested
+        if NifOp.props.guess_armature_orientation:
+            forward, up = self.guess_orientation(n_armature)
+        else:
+            forward, up = (NifOp.props.armature_axis_forward, NifOp.props.armature_axis_up)
         # pass them to the matrix utility
         math.set_bone_orientation(forward, up)
         # store axis orientation for export

--- a/io_scene_niftools/operators/nif_import_op.py
+++ b/io_scene_niftools/operators/nif_import_op.py
@@ -117,6 +117,41 @@ class NifImportOperator(Operator, ImportHelper, CommonScale, CommonDevOperator, 
         description="Loads texture embedded in .nif",
         default=False)
 
+    #Automatically detect armature orientation
+    guess_armature_orientation: bpy.props.BoolProperty(
+        name="Guess Armature Orientation",
+        description="Automatically detect armature orientation",
+        default=True)
+
+    #Specify axis_forward
+    armature_axis_forward: bpy.props.EnumProperty(
+        items=(
+            ("X", "X", ""),
+            ("Y", "Y", ""),
+            ("Z", "Z", ""),
+            ("-X", "-X", ""),
+            ("-Y", "-Y", ""),
+            ("-Z", "-Z", ""),
+        ),
+        name="Axis Forward",
+        description="Specify axis_forward",
+        default="Y")
+
+    #Specify axis_up
+    armature_axis_up: bpy.props.EnumProperty(
+        items=(
+            ("X", "X", ""),
+            ("Y", "Y", ""),
+            ("Z", "Z", ""),
+            ("-X", "-X", ""),
+            ("-Y", "-Y", ""),
+            ("-Z", "-Z", ""),
+        ),
+        name="Axis Up",
+        description="Specify axis_up",
+        default="X")
+
+
     def draw(self, context):
         pass
 

--- a/io_scene_niftools/operators/nif_import_op.py
+++ b/io_scene_niftools/operators/nif_import_op.py
@@ -118,10 +118,10 @@ class NifImportOperator(Operator, ImportHelper, CommonScale, CommonDevOperator, 
         default=False)
 
     #Automatically detect armature orientation
-    guess_armature_orientation: bpy.props.BoolProperty(
-        name="Guess Armature Orientation",
-        description="Automatically detect armature orientation",
-        default=True)
+    override_armature_orientation: bpy.props.BoolProperty(
+        name="Override Armature Orientation",
+        description="Override detected armature orientation",
+        default=False)
 
     #Specify axis_forward
     armature_axis_forward: bpy.props.EnumProperty(
@@ -134,7 +134,7 @@ class NifImportOperator(Operator, ImportHelper, CommonScale, CommonDevOperator, 
             ("-Z", "-Z", ""),
         ),
         name="Axis Forward",
-        description="Specify axis_forward",
+        description="Specify the forward axis",
         default="Y")
 
     #Specify axis_up
@@ -148,7 +148,7 @@ class NifImportOperator(Operator, ImportHelper, CommonScale, CommonDevOperator, 
             ("-Z", "-Z", ""),
         ),
         name="Axis Up",
-        description="Specify axis_up",
+        description="Specify the up axis",
         default="X")
 
 

--- a/io_scene_niftools/operators/nif_import_op.py
+++ b/io_scene_niftools/operators/nif_import_op.py
@@ -45,7 +45,7 @@ from io_scene_niftools.nif_import import NifImport
 from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonNif
 from io_scene_niftools.utils.decorators import register_classes, unregister_classes
 
-@orientation_helper(axis_forward='-Z', axis_up='Y')
+@orientation_helper(axis_forward='Z', axis_up='-Y')
 class NifImportOperator(Operator, ImportHelper, CommonScale, CommonDevOperator, CommonNif):
     """Operator for loading a nif file."""
 

--- a/io_scene_niftools/operators/nif_import_op.py
+++ b/io_scene_niftools/operators/nif_import_op.py
@@ -39,13 +39,13 @@
 
 import bpy
 from bpy.types import Operator, Panel
-from bpy_extras.io_utils import ImportHelper
+from bpy_extras.io_utils import ImportHelper, orientation_helper
 
 from io_scene_niftools.nif_import import NifImport
 from io_scene_niftools.operators.common_op import CommonDevOperator, CommonScale, CommonNif
 from io_scene_niftools.utils.decorators import register_classes, unregister_classes
 
-
+@orientation_helper(axis_forward='-Z', axis_up='Y')
 class NifImportOperator(Operator, ImportHelper, CommonScale, CommonDevOperator, CommonNif):
     """Operator for loading a nif file."""
 
@@ -122,34 +122,6 @@ class NifImportOperator(Operator, ImportHelper, CommonScale, CommonDevOperator, 
         name="Override Armature Orientation",
         description="Override detected armature orientation",
         default=False)
-
-    #Specify axis_forward
-    armature_axis_forward: bpy.props.EnumProperty(
-        items=(
-            ("X", "X", ""),
-            ("Y", "Y", ""),
-            ("Z", "Z", ""),
-            ("-X", "-X", ""),
-            ("-Y", "-Y", ""),
-            ("-Z", "-Z", ""),
-        ),
-        name="Axis Forward",
-        description="Specify the forward axis",
-        default="Y")
-
-    #Specify axis_up
-    armature_axis_up: bpy.props.EnumProperty(
-        items=(
-            ("X", "X", ""),
-            ("Y", "Y", ""),
-            ("Z", "Z", ""),
-            ("-X", "-X", ""),
-            ("-Y", "-Y", ""),
-            ("-Z", "-Z", ""),
-        ),
-        name="Axis Up",
-        description="Specify the up axis",
-        default="X")
 
 
     def draw(self, context):

--- a/io_scene_niftools/ui/operators/nif_import.py
+++ b/io_scene_niftools/ui/operators/nif_import.py
@@ -161,13 +161,13 @@ class OperatorImportArmaturePanel(OperatorSetting, Panel):
         layout.prop(operator, "send_geoms_to_bind_pos")
         layout.prop(operator, "apply_skin_deformation")
 
-        layout.prop(operator, "guess_armature_orientation")
+        layout.prop(operator, "override_armature_orientation")
         row_ax_fwd = layout.row()
         row_ax_fwd.prop(operator, "armature_axis_forward")
-        row_ax_fwd.enabled = not operator.guess_armature_orientation #Grey out if guessing orientation is requested
+        row_ax_fwd.enabled = operator.override_armature_orientation #Grey out unless requesting override
         row_ax_up = layout.row()
         row_ax_up.prop(operator, "armature_axis_up")
-        row_ax_up.enabled = not operator.guess_armature_orientation
+        row_ax_up.enabled = operator.override_armature_orientation
 
 class OperatorImportAnimationPanel(OperatorSetting, Panel):
     bl_options = {'DEFAULT_CLOSED'}

--- a/io_scene_niftools/ui/operators/nif_import.py
+++ b/io_scene_niftools/ui/operators/nif_import.py
@@ -161,6 +161,13 @@ class OperatorImportArmaturePanel(OperatorSetting, Panel):
         layout.prop(operator, "send_geoms_to_bind_pos")
         layout.prop(operator, "apply_skin_deformation")
 
+        layout.prop(operator, "guess_armature_orientation")
+        row_ax_fwd = layout.row()
+        row_ax_fwd.prop(operator, "armature_axis_forward")
+        row_ax_fwd.enabled = not operator.guess_armature_orientation #Grey out if guessing orientation is requested
+        row_ax_up = layout.row()
+        row_ax_up.prop(operator, "armature_axis_up")
+        row_ax_up.enabled = not operator.guess_armature_orientation
 
 class OperatorImportAnimationPanel(OperatorSetting, Panel):
     bl_options = {'DEFAULT_CLOSED'}

--- a/io_scene_niftools/ui/operators/nif_import.py
+++ b/io_scene_niftools/ui/operators/nif_import.py
@@ -38,7 +38,6 @@
 # ***** END LICENSE BLOCK *****
 
 from bpy.types import Panel
-
 from io_scene_niftools.utils.decorators import register_classes, unregister_classes
 
 
@@ -162,12 +161,31 @@ class OperatorImportArmaturePanel(OperatorSetting, Panel):
         layout.prop(operator, "apply_skin_deformation")
 
         layout.prop(operator, "override_armature_orientation")
-        row_ax_fwd = layout.row()
-        row_ax_fwd.prop(operator, "armature_axis_forward")
-        row_ax_fwd.enabled = operator.override_armature_orientation #Grey out unless requesting override
-        row_ax_up = layout.row()
-        row_ax_up.prop(operator, "armature_axis_up")
-        row_ax_up.enabled = operator.override_armature_orientation
+
+
+class OperatorImportOverrideArmatureOrientationPanel(OperatorSetting, Panel):
+    bl_label = "Override Armature Orientation"
+    bl_idname = "NIFTOOLS_PT_import_operator_override_armature_orientation"
+
+    @classmethod
+    def poll(cls, context):
+        sfile = context.space_data
+        operator = sfile.active_operator
+
+        return operator.bl_idname == "IMPORT_SCENE_OT_nif"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation.
+
+        sfile = context.space_data
+        operator = sfile.active_operator
+
+        layout.enabled = operator.override_armature_orientation
+
+        layout.prop(operator, "axis_forward")
+        layout.prop(operator, "axis_up")
 
 class OperatorImportAnimationPanel(OperatorSetting, Panel):
     bl_options = {'DEFAULT_CLOSED'}
@@ -201,6 +219,7 @@ classes = [
     OperatorImportGeometryPanel,
     OperatorImportTexturePanel,
     OperatorImportArmaturePanel,
+    OperatorImportOverrideArmatureOrientationPanel,
     OperatorImportAnimationPanel
 ]
 


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
When importing armatures, axis are currently set automatically by the guess_orientation function in nif_import/armature/init.py
```
# use heuristics to determine a suitable orientation 
forward, up = self.guess_orientation(n_armature) 
# pass them to the matrix utility 
math.set_bone_orientation(forward, up)
```
Some times it would be valuable to be able to set these manually, example is if you have a rigged armature in the scene with a specific orientation and want to import another armature with matching orientation.

##  Detailed Description
**[List of functional updates]**

## Fixes Known Issues
**[Ordered list of issues fixed by this PR]**

## Documentation
**[Overview of updates to documentation]**
I put in a block in the draw() call for setting axis if guess orientation is checked, that together with the operator descriptions is hopefully clear enough?

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**
Import nif skeleton with guess armature checked, then import the same armature again with different orientations checked. 
Compare bone rolls.

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
