### PR TITLE
BSLagBoneController support

### DIFF
--- a/io_scene_niftools/modules/nif_export/armature/__init__.py
+++ b/io_scene_niftools/modules/nif_export/armature/__init__.py
@@ -83,8 +83,8 @@ class Armature:
         for b_child in b_bone.children:
             self.export_bone(b_obj, b_child, n_node, n_root_node)
 
-        if b_bone.niftools.BSLagBoneController:
-            self.export_BSLagBoneController(b_bone, n_node)
+        if b_bone.niftools.lag_bone.enabled:
+            self.export_lag_bone(b_bone, n_node)
 
     def export_bone_flags(self, b_bone, n_node):
         """Exports or sets the flags according to the custom data in b_bone or the game version if none was set"""
@@ -115,7 +115,7 @@ class Armature:
             else:
                 n_node.flags = 0x0002  # default for Morrowind bones
 
-    def export_BSLagBoneController(self, b_bone, n_node):
+    def export_lag_bone(self, b_bone, n_node):
         """Exports a BSLagBoneController for the bone"""
 
         #BSLagBoneControllers are only for skyrim and later, afaik
@@ -126,13 +126,13 @@ class Armature:
         n_controller = block_store.create_block("BSLagBoneController")
         n_controller.name = block_store.get_full_name(b_bone)
         #This should be active and cycle, what I've seen in game.
-        n_controller.flags = b_bone.niftools.BSLagBoneController_flags #0x0048? hexa?
+        n_controller.flags = b_bone.niftools.lag_bone.flags #0x0048? hexa?
         n_controller.frequency = 1.0
         n_controller.phase = 0.0
         n_controller.start_time = consts.FLOAT_MIN
         n_controller.stop_time = consts.FLOAT_MAX
-        n_controller.linear_velocity = b_bone.niftools.BSLagBoneController_linear_velocity
-        n_controller.linear_rotation = b_bone.niftools.BSLagBoneController_linear_rotation
-        n_controller.maximum_distance = b_bone.niftools.BSLagBoneController_maximum_distance
+        n_controller.linear_velocity = b_bone.niftools.lag_bone.linear_velocity
+        n_controller.linear_rotation = b_bone.niftools.lag_bone.linear_rotation
+        n_controller.maximum_distance = b_bone.niftools.lag_bone.maximum_distance
         #add controller to _this_ block
         n_node.add_controller(n_controller)

--- a/io_scene_niftools/modules/nif_import/armature/__init__.py
+++ b/io_scene_niftools/modules/nif_import/armature/__init__.py
@@ -242,12 +242,12 @@ class Armature:
         ctrl = n_block.controller
         if isinstance(ctrl, NifFormat.BSLagBoneController):
             #Enable bscontrollerlagboneprop
-            b_bone.niftools.BSLagBoneController = True
+            b_bone.niftools.lag_bone.enabled = True
             #Set the props we care about; flags, linear_velocity, linear_rotation, maximum distance
-            b_bone.niftools.BSLagBoneController_flags = ctrl.flags
-            b_bone.niftools.BSLagBoneController_linear_velocity = ctrl.linear_velocity
-            b_bone.niftools.BSLagBoneController_linear_rotation = ctrl.linear_rotation
-            b_bone.niftools.BSLagBoneController_maximum_distance = ctrl.maximum_distance
+            b_bone.niftools.lag_bone.flags = ctrl.flags
+            b_bone.niftools.lag_bone.linear_velocity = ctrl.linear_velocity
+            b_bone.niftools.lag_bone.linear_rotation = ctrl.linear_rotation
+            b_bone.niftools.lag_bone.maximum_distance = ctrl.maximum_distance
 
     def import_bone_bind(self, n_block, b_armature_data, n_armature, b_parent_bone=None):
         """Adds a bone to the armature in edit mode."""

--- a/io_scene_niftools/properties/armature.py
+++ b/io_scene_niftools/properties/armature.py
@@ -50,6 +50,33 @@ from bpy.types import PropertyGroup
 from io_scene_niftools.utils.decorators import register_classes, unregister_classes
 
 
+class LagBoneControllerProperty(PropertyGroup):
+    enabled: BoolProperty(
+        name='BSLagBoneController',
+        default=False
+    )
+
+    flags: IntProperty(
+        name='flags',
+        default=72
+    )
+
+    linear_velocity: FloatProperty(
+        name='linear velocity',
+        default=20.0
+    )
+
+    linear_rotation: FloatProperty(
+        name='linear rotation',
+        default=20.0
+    )
+
+    maximum_distance: FloatProperty(
+        name='maximum distance',
+        default=10.0
+    )
+
+
 class BoneProperty(PropertyGroup):
     flags: IntProperty(
         name='Bone Flag',
@@ -63,63 +90,38 @@ class BoneProperty(PropertyGroup):
         name='Nif Long Name'
     )
 
-    #BSLagbone properties
-
-    BSLagBoneController: BoolProperty(
-        name='BSLagBoneController',
-        default=False
-    )
-
-    BSLagBoneController_flags: IntProperty(
-        name='flags',
-        default=72
-    )
-
-    BSLagBoneController_linear_velocity: FloatProperty(
-        name='linear velocity',
-        default=20.0
-    )
-
-    BSLagBoneController_linear_rotation: FloatProperty(
-        name='linear rotation',
-        default=20.0
-    )
-
-    BSLagBoneController_maximum_distance: FloatProperty(
-        name='maximum distance',
-        default=10.0
-    )
-
+    lag_bone: PointerProperty(type=LagBoneControllerProperty)
 
 
 class ArmatureProperty(PropertyGroup):
 
     axis_forward: EnumProperty(
-            name="Forward",
-            items=(('X', "X Forward", ""),
-                   ('Y', "Y Forward", ""),
-                   ('Z', "Z Forward", ""),
-                   ('-X', "-X Forward", ""),
-                   ('-Y', "-Y Forward", ""),
-                   ('-Z', "-Z Forward", ""),
-                   ),
-            default="X",
-            )
+        name="Forward",
+        items=(('X', "X Forward", ""),
+               ('Y', "Y Forward", ""),
+               ('Z', "Z Forward", ""),
+               ('-X', "-X Forward", ""),
+               ('-Y', "-Y Forward", ""),
+               ('-Z', "-Z Forward", ""),
+               ),
+        default="X",
+    )
 
     axis_up: EnumProperty(
-            name="Up",
-            items=(('X', "X Up", ""),
-                   ('Y', "Y Up", ""),
-                   ('Z', "Z Up", ""),
-                   ('-X', "-X Up", ""),
-                   ('-Y', "-Y Up", ""),
-                   ('-Z', "-Z Up", ""),
-                   ),
-            default="Y",
-            )
+        name="Up",
+        items=(('X', "X Up", ""),
+               ('Y', "Y Up", ""),
+               ('Z', "Z Up", ""),
+               ('-X', "-X Up", ""),
+               ('-Y', "-Y Up", ""),
+               ('-Z', "-Z Up", ""),
+               ),
+        default="Y",
+    )
 
 
 CLASSES = [
+    LagBoneControllerProperty,
     BoneProperty,
     ArmatureProperty
 ]
@@ -130,6 +132,7 @@ def register():
 
     bpy.types.Armature.niftools = bpy.props.PointerProperty(type=ArmatureProperty)
     bpy.types.Bone.niftools = bpy.props.PointerProperty(type=BoneProperty)
+
 
 def unregister():
     del bpy.types.Armature.niftools

--- a/io_scene_niftools/ui/armature.py
+++ b/io_scene_niftools/ui/armature.py
@@ -79,13 +79,13 @@ class BoneControllerPanel(Panel):
         nif_bone_props = context.bone.niftools
 
         row = self.layout.column()
-        row.prop(nif_bone_props, "BSLagBoneController")
+        row.prop(nif_bone_props.lag_bone, "enabled")
         row2 = self.layout.column()
-        row2.prop(nif_bone_props, "BSLagBoneController_flags")
-        row2.prop(nif_bone_props, "BSLagBoneController_linear_velocity")
-        row2.prop(nif_bone_props, "BSLagBoneController_linear_rotation")
-        row2.prop(nif_bone_props, "BSLagBoneController_maximum_distance")
-        row2.enabled = nif_bone_props.BSLagBoneController
+        row2.prop(nif_bone_props.lag_bone, "flags")
+        row2.prop(nif_bone_props.lag_bone, "linear_velocity")
+        row2.prop(nif_bone_props.lag_bone, "linear_rotation")
+        row2.prop(nif_bone_props.lag_bone, "maximum_distance")
+        row2.enabled = nif_bone_props.lag_bone.enabled
 
 
 


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
**[Overview of the content of the pull request]**
BSLagBoneControllers are available in the nifformat but not exposed, this is a simple setup to allow for import and export.

##  Detailed Description
**[List of functional updates]**
The implementation is entirely custom property driven on niftools bone properties, it doesn't cause any actual behavior on the blender side. The behavior of lagbones would be quite similar to 'wiggle' or 'jiggly' bones in blender but those are addons, afaik similar functionality doesn't exist in base blender...

## Fixes Known Issues
**[Ordered list of issues fixed by this PR]**
None, new feature

## Documentation
**[Overview of updates to documentation]**
I should add some, if you think this PR has some merit.
Afaik lagbones are Skyrim only and in LE they work for skeletons and skins, whereas in SSE its skeleton only (caveat; I think this is the case, might be off)

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**
Import/export nif with bslagbones set.

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
I've not set up properties for everything, just the ones I think are meaningful, should I? 
Should this be refactored/ placed somewhere else?