### PR TITLE
NiMesh import and updates for newer xml.

### DIFF
--- a/io_scene_niftools/kf_export.py
+++ b/io_scene_niftools/kf_export.py
@@ -65,7 +65,7 @@ class KfExport(NifCommon):
         directory = os.path.dirname(NifOp.props.filepath)
         filebase, fileext = os.path.splitext(os.path.basename(NifOp.props.filepath))
 
-        if bpy.context.scene.niftools_scene.game == 'NONE':
+        if bpy.context.scene.niftools_scene.game == 'UNKNOWN':
             raise NifError("You have not selected a game. Please select a game in the scene tab.")
 
         prefix = "x" if bpy.context.scene.niftools_scene.game in ('MORROWIND',) else ""

--- a/io_scene_niftools/modules/nif_export/collision/havok.py
+++ b/io_scene_niftools/modules/nif_export/collision/havok.py
@@ -242,17 +242,12 @@ class BhkCollision(Collision):
     def export_bhk_packed_nitristrip_shape(self, b_obj, n_col_mopp):
         # the mopp origin, scale, and data are written later
         n_col_shape = block_store.create_block("bhkPackedNiTriStripsShape", b_obj)
-        n_col_shape.unknown_int_1 = 0
-        n_col_shape.unknown_int_2 = 21929432
-        n_col_shape.unknown_float_1 = 0.1
-        n_col_shape.unknown_int_3 = 0
-        n_col_shape.unknown_float_2 = 0
-        n_col_shape.unknown_float_3 = 0.1
+        # TODO [collision] radius has default of 0.1, but maybe let depend on margin
         scale = n_col_shape.scale
         scale.x = 0
         scale.y = 0
         scale.z = 0
-        scale.unknown_float_4 = 0
+        scale.w = 0
         n_col_shape.scale_copy = scale
         n_col_mopp.shape = n_col_shape
         return n_col_shape
@@ -310,17 +305,7 @@ class BhkCollision(Collision):
             n_coltf = block_store.create_block("bhkConvexTransformShape", b_obj)
 
             # n_coltf.material = n_havok_mat[0]
-            n_coltf.unknown_float_1 = 0.1
-
-            unk_8 = n_coltf.unknown_8_bytes
-            unk_8[0] = 96
-            unk_8[1] = 120
-            unk_8[2] = 53
-            unk_8[3] = 19
-            unk_8[4] = 24
-            unk_8[5] = 9
-            unk_8[6] = 253
-            unk_8[7] = 4
+            n_coltf.radius = radius
 
             hktf = math.get_object_bind(b_obj)
             # the translation part must point to the center of the data
@@ -351,16 +336,6 @@ class BhkCollision(Collision):
                 n_coltf.shape = n_colbox
                 # n_colbox.material = n_havok_mat[0]
                 n_colbox.radius = radius
-
-                unk_8 = n_colbox.unknown_8_bytes
-                unk_8[0] = 0x6b
-                unk_8[1] = 0xee
-                unk_8[2] = 0x43
-                unk_8[3] = 0x40
-                unk_8[4] = 0x3a
-                unk_8[5] = 0xef
-                unk_8[6] = 0x8e
-                unk_8[7] = 0x3e
 
                 # fix dimensions for havok coordinate system
                 box_extends = self.calculate_box_extents(b_obj)

--- a/io_scene_niftools/modules/nif_export/collision/havok.py
+++ b/io_scene_niftools/modules/nif_export/collision/havok.py
@@ -252,9 +252,9 @@ class BhkCollision(Collision):
         n_col_mopp.shape = n_col_shape
         return n_col_shape
 
-    def export_bhk_convex_vertices_shape(self, b_obj, fdistlist, fnormlist, radius, vertlist):
+    def export_bhk_convex_vertices_shape(self, b_obj, fdistlist, fnormlist, radius, vertlist, n_havok_mat):
         colhull = block_store.create_block("bhkConvexVerticesShape", b_obj)
-        # colhull.material = n_havok_mat[0]
+        colhull.material.material = n_havok_mat
         colhull.radius = radius
 
         # Vertices
@@ -304,7 +304,7 @@ class BhkCollision(Collision):
             # note: collision settings are taken from lowerclasschair01.nif
             n_coltf = block_store.create_block("bhkConvexTransformShape", b_obj)
 
-            # n_coltf.material = n_havok_mat[0]
+            n_coltf.material.material = n_havok_mat
             n_coltf.radius = radius
 
             hktf = math.get_object_bind(b_obj)
@@ -334,7 +334,7 @@ class BhkCollision(Collision):
             if collision_shape == 'BOX':
                 n_colbox = block_store.create_block("bhkBoxShape", b_obj)
                 n_coltf.shape = n_colbox
-                # n_colbox.material = n_havok_mat[0]
+                n_colbox.material.material = n_havok_mat
                 n_colbox.radius = radius
 
                 # fix dimensions for havok coordinate system
@@ -348,7 +348,7 @@ class BhkCollision(Collision):
             elif collision_shape == 'SPHERE':
                 n_colsphere = block_store.create_block("bhkSphereShape", b_obj)
                 n_coltf.shape = n_colsphere
-                # n_colsphere.material = n_havok_mat[0]
+                n_colsphere.material.material = n_havok_mat
                 # TODO [object][collision] find out what this is: fix for havok coordinate system (6 * 7 = 42)
                 # take average radius
                 n_colsphere.radius = radius
@@ -372,8 +372,7 @@ class BhkCollision(Collision):
             second_point /= self.HAVOK_SCALE
 
             n_col_caps = block_store.create_block("bhkCapsuleShape", b_obj)
-            # n_col_caps.material = n_havok_mat[0]
-            # n_col_caps.skyrim_material = n_havok_mat[1]
+            n_col_caps.material.material = n_havok_mat
 
             cap_1 = n_col_caps.first_point
             cap_1.x = first_point.x
@@ -434,7 +433,7 @@ class BhkCollision(Collision):
             if len(fnormlist) > 65535 or len(vertlist) > 65535:
                 raise io_scene_niftools.utils.logging.NifError("Mesh has too many polygons/vertices. Simply/split your mesh and try again.")
 
-            return self.export_bhk_convex_vertices_shape(b_obj, fdistlist, fnormlist, radius, vertlist)
+            return self.export_bhk_convex_vertices_shape(b_obj, fdistlist, fnormlist, radius, vertlist, n_havok_mat)
 
         else:
             raise io_scene_niftools.utils.logging.NifError(f'Cannot export collision type {collision_shape} to collision shape list')
@@ -501,7 +500,7 @@ class BhkCollision(Collision):
         if not n_col_body.shape:
             n_col_shape = block_store.create_block("bhkListShape")
             n_col_body.shape = n_col_shape
-            # n_col_shape.material = n_havok_mat[0]
+            n_col_shape.material.material = n_havok_mat
         else:
             n_col_shape = n_col_body.shape
             if not isinstance(n_col_shape, NifClasses.BhkListShape):

--- a/io_scene_niftools/modules/nif_export/collision/havok.py
+++ b/io_scene_niftools/modules/nif_export/collision/havok.py
@@ -186,7 +186,6 @@ class BhkCollision(Collision):
 
     def export_bhk_blend_collision(self, b_obj):
         n_col_obj = block_store.create_block("bhkBlendCollisionObject", b_obj)
-        n_col_obj.flags = 9
         n_col_obj.unknown_float_1 = 1.0
         n_col_obj.unknown_float_2 = 1.0
         return n_col_obj

--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -253,7 +253,7 @@ class Mesh:
 
                     fuv = [uv_layer.data[loop_index].uv for uv_layer in eval_mesh.uv_layers]
 
-                    # TODO [geomotry][mesh] Need to map b_verts -> n_verts
+                    # TODO [geometry][mesh] Need to map b_verts -> n_verts
                     if mesh_hasvcol:
                         f_col = list(eval_mesh.vertex_colors[0].data[loop_index].color)
                     else:
@@ -742,6 +742,7 @@ class Mesh:
         return n_block
 
     def get_triangulated_mesh(self, b_obj):
+        # TODO [geometry][mesh] triangulation could also be done using loop_triangles, without a modifier
         # get the armature influencing this mesh, if it exists
         b_armature_obj = b_obj.find_armature()
         if b_armature_obj:
@@ -775,7 +776,7 @@ class Mesh:
         if as_extra_data:
             # if tangent space extra data already exists, use it
             # find possible extra data block
-            extra_name = b'Tangent space (binormal & tangent vectors)'
+            extra_name = 'Tangent space (binormal & tangent vectors)'
             for extra in n_geom.get_extra_datas():
                 if isinstance(extra, NifClasses.NiBinaryExtraData):
                     if extra.name == extra_name:

--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -493,9 +493,8 @@ class Mesh:
                     NifLog.warn(f"Using more than {rec_bones} bones per partition on {game} export."
                                 f"This may cause issues in-game.")
 
-            part_order = [NifClasses.BSDismemberBodyPartType.get(face_map.name) for face_map in
-                          b_obj.face_maps]
-            part_order = [body_part for body_part in part_order if body_part is not None]
+            part_order = [NifClasses.BSDismemberBodyPartType[face_map.name] for face_map in
+                          b_obj.face_maps if face_map.name in NifClasses.BSDismemberBodyPartType.__members__]
             # override pyffi n_geom.update_skin_partition with custom one (that allows ordering)
             n_geom.update_skin_partition = update_skin_partition.__get__(n_geom)
             lostweight = n_geom.update_skin_partition(

--- a/io_scene_niftools/modules/nif_export/object/__init__.py
+++ b/io_scene_niftools/modules/nif_export/object/__init__.py
@@ -98,16 +98,15 @@ class Object:
         #     self.export_collision(b_obj, n_parent)
         #     return None  # done; stop here
         self.n_root = None
-        node_type = bpy.context.scene.niftools_scene.rootnode
         # there is only one root object so that will be our final root
         if len(root_objects) == 1:
             b_obj = root_objects[0]
-            self.export_node(b_obj, None, n_node_type=node_type)
+            self.export_node(b_obj, None, n_node_type=b_obj.niftools.nodetype)
 
         # there is more than one root object so we create a meta root
         else:
             NifLog.info(f"Created meta root because blender scene had {len(root_objects)} root objects")
-            self.n_root = types.create_ninode(n_node_type=node_type)
+            self.n_root = types.create_ninode()
             self.n_root.name = "Scene Root"
             for b_obj in root_objects:
                 self.export_node(b_obj, self.n_root)

--- a/io_scene_niftools/modules/nif_export/property/object/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/object/__init__.py
@@ -45,7 +45,6 @@ from generated.formats.nif import classes as NifClasses
 from io_scene_niftools.modules.nif_export.property.material import MaterialProp
 from io_scene_niftools.modules.nif_export.property.shader import BSShaderProperty
 from io_scene_niftools.modules.nif_export.property.texture.types.nitextureprop import NiTextureProp
-from io_scene_niftools.properties.object import PRN_DICT
 from io_scene_niftools.modules.nif_export.block_registry import block_store
 from io_scene_niftools.utils.consts import UPB_DEFAULT
 from io_scene_niftools.utils.singleton import NifOp
@@ -240,11 +239,10 @@ class ObjectDataProperty:
         game = bpy.context.scene.niftools_scene.game
         if game in ('OBLIVION', 'FALLOUT_3', 'SKYRIM'):
             loc = root_obj.niftools.prn_location
-            if loc != "NONE" and (PRN_DICT[loc][game] is not None):
-                # add string extra data
+            if loc:
                 prn = block_store.create_block("NiStringExtraData")
                 prn.name = 'Prn'
-                prn.string_data = PRN_DICT[loc][game]
+                prn.string_data = loc
                 n_root.add_extra_data(prn)
 
     # TODO [object][property] Move to object property

--- a/io_scene_niftools/modules/nif_export/property/object/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/object/__init__.py
@@ -71,7 +71,8 @@ class ObjectProperty:
                          self.export_specular_property(b_mat),
                          self.material_property.export_material_property(b_mat)
                          ):
-                n_block.add_property(prop)
+                if prop is not None:
+                    n_block.add_property(prop)
 
             # todo [property] refactor this
             # add textures

--- a/io_scene_niftools/modules/nif_export/types.py
+++ b/io_scene_niftools/modules/nif_export/types.py
@@ -55,7 +55,10 @@ def create_ninode(b_obj=None, n_node_type=None):
     else:
         # let n_node_type overwrite the detected node type
         if n_node_type is None:
-            n_node_type = b_obj.niftools.nodetype
+            try:
+                n_node_type = b_obj.niftools.nodetype
+            except AttributeError:
+                n_node_type = "NiNode"
 
             # ...others by presence of constraints
             if has_track(b_obj):

--- a/io_scene_niftools/modules/nif_export/types.py
+++ b/io_scene_niftools/modules/nif_export/types.py
@@ -55,10 +55,7 @@ def create_ninode(b_obj=None, n_node_type=None):
     else:
         # let n_node_type overwrite the detected node type
         if n_node_type is None:
-            try:
-                n_node_type = b_obj["type"]
-            except KeyError:
-                n_node_type = "NiNode"
+            n_node_type = b_obj.niftools.nodetype
 
             # ...others by presence of constraints
             if has_track(b_obj):

--- a/io_scene_niftools/modules/nif_import/animation/transform.py
+++ b/io_scene_niftools/modules/nif_import/animation/transform.py
@@ -257,12 +257,13 @@ class TransformAnimation(Animation):
                 # keys = list(kfc._getCompKeys(kfc.offset, 1, kfc.bias, kfc.multiplier))
                 return
             times = list(n_kfc.get_times())
-            keys = list(n_kfc.get_translations())
+            keys = [NifClasses.Vector3.from_value(tuple_key) for tuple_key in n_kfc.get_translations()]
             self.import_keys(LOC, b_action, bone_name, times, keys, flags, interp, n_bind_rot_inv, n_bind_trans)
-            keys = list(n_kfc.get_rotations())
+            keys = [NifClasses.Quaternion.from_value(tuple_key) for tuple_key in n_kfc.get_rotations()]
             self.import_keys(QUAT, b_action, bone_name, times, keys, flags, interp, n_bind_rot_inv, n_bind_trans)
             keys = list(n_kfc.get_scales())
             self.import_keys(SCALE, b_action, bone_name, times, keys, flags, interp, n_bind_rot_inv, n_bind_trans)
+            return b_action
         elif isinstance(n_kfc, NifClasses.NiMultiTargetTransformController):
             # not sure what this is used for
             return

--- a/io_scene_niftools/modules/nif_import/armature/__init__.py
+++ b/io_scene_niftools/modules/nif_import/armature/__init__.py
@@ -46,7 +46,7 @@ from generated.formats.nif import classes as NifClasses
 
 
 import io_scene_niftools.utils.logging
-from io_scene_niftools.modules.nif_import.object.block_registry import block_store
+from io_scene_niftools.modules.nif_import.object.block_registry import block_store, get_bone_name_for_blender
 from io_scene_niftools.modules.nif_export.block_registry import block_store as block_store_export
 from io_scene_niftools.modules.nif_import.animation.transform import TransformAnimation
 from io_scene_niftools.modules.nif_import.object import Object
@@ -81,7 +81,7 @@ class Armature:
     def get_skinned_geometries(self, n_root):
         """Yield all children in n_root's tree that have skinning"""
         # search for all NiTriShape or NiTriStrips blocks...
-        for n_block in n_root.tree(block_type=(NifClasses.NiTriBasedGeom, NifClasses.BSTriShape)):
+        for n_block in n_root.tree(block_type=(NifClasses.NiTriBasedGeom, NifClasses.BSTriShape, NifClasses.NiMesh)):
             # yes, we found one, does it have skinning?
             if n_block.is_skin():
                 yield n_block
@@ -109,50 +109,57 @@ class Armature:
         # improved from pyffi's send_geometries_to_bind_position & send_bones_to_bind_position
         NifLog.debug(f"Calculating bind for {n_armature.name}")
         # prioritize geometries that have most nodes in their skin instance
-        geoms = sorted(self.get_skinned_geometries(n_armature), key=lambda g: g.skin_instance.num_bones, reverse=True)
+        sort_function = lambda g: len(g.extra_em_data.bone_transforms) if isinstance(g, NifClasses.NiMesh) else g.skin_instance.num_bones
+        geoms = sorted(self.get_skinned_geometries(n_armature), key=sort_function, reverse=True)
         NifLog.debug(f"Found {len(geoms)} skinned geometries")
         for geom in geoms:
             NifLog.debug(f"Checking skin of {geom.name}")
-            skininst = geom.skin_instance
-            for bonenode, bonedata in self.bones_iter(skininst):
-                # make sure all bone data of shared bones coincides
-                # see if the bone has been used by a previous skin instance
-                if bonenode in self.bind_store:
-                    # get the bind pose that has been stored
-                    diff = (bonedata.get_transform()
-                            * self.bind_store[bonenode]
-                            # * geom.skin_instance.data.get_transform())  use this if relative to skin instead of geom
-                            * geom.get_transform(n_armature).get_inverse(fast=False))
-                    # there is a difference between the two geometries' bind poses
-                    if not diff.is_identity():
-                        NifLog.debug(f"Fixing {geom.name} bind position")
-                        # update the skin for all bones of the new geom
-                        for bonenode, bonedata in self.bones_iter(skininst):
-                            NifLog.debug(f"Transforming bind of {bonenode.name}")
-                            bonedata.set_transform(diff.get_inverse(fast=False) * bonedata.get_transform())
-                    # transforming verts helps with nifs where the skins differ, eg MW vampire or WLP2 Gastornis
-                    if isinstance(geom, NifClasses.BSTriShape):
-                        vertices = [vert_data.vertex for vert_data in geom.skin.skin_partition.vertex_data]
-                        normals = [vert_data.normal for vert_data in geom.skin.skin_partition.vertex_data]
-                    else:
-                        vertices = geom.data.vertices
-                        normals = geom.data.normals
-                    for vert in vertices:
-                        newvert = vert * diff
-                        vert.x = newvert.x
-                        vert.y = newvert.y
-                        vert.z = newvert.z
-                    diff33 = diff.get_matrix_33()
-                    for norm in normals:
-                        newnorm = norm * diff33
-                        norm.x = newnorm.x
-                        norm.y = newnorm.y
-                        norm.z = newnorm.z
-                    break
-            # store bind pose
-            for bonenode, bonedata in self.bones_iter(skininst):
-                NifLog.debug(f"Stored {geom.name} bind position")
-                self.bind_store[bonenode] = self.get_skin_bind(bonedata, geom, n_armature)
+            if isinstance(geom, NifClasses.NiMesh):
+                # bones have no names and are not associated with any NiNodes
+                for i, bone_transform in enumerate(geom.extra_em_data.bone_transforms):
+                    # Use transpose because the matrices are stored transposed to usual format.
+                    self.bind_store[i] = bone_transform.get_transpose().get_inverse(fast=False) * geom.get_transform(n_armature)
+            else:
+                skininst = geom.skin_instance
+                for bonenode, bonedata in self.bones_iter(skininst):
+                    # make sure all bone data of shared bones coincides
+                    # see if the bone has been used by a previous skin instance
+                    if bonenode in self.bind_store:
+                        # get the bind pose that has been stored
+                        diff = (bonedata.get_transform()
+                                * self.bind_store[bonenode]
+                                # * geom.skin_instance.data.get_transform())  use this if relative to skin instead of geom
+                                * geom.get_transform(n_armature).get_inverse(fast=False))
+                        # there is a difference between the two geometries' bind poses
+                        if not diff.is_identity():
+                            NifLog.debug(f"Fixing {geom.name} bind position")
+                            # update the skin for all bones of the new geom
+                            for bonenode, bonedata in self.bones_iter(skininst):
+                                NifLog.debug(f"Transforming bind of {bonenode.name}")
+                                bonedata.set_transform(diff.get_inverse(fast=False) * bonedata.get_transform())
+                        # transforming verts helps with nifs where the skins differ, eg MW vampire or WLP2 Gastornis
+                        if isinstance(geom, NifClasses.BSTriShape):
+                            vertices = [vert_data.vertex for vert_data in geom.skin.skin_partition.vertex_data]
+                            normals = [vert_data.normal for vert_data in geom.skin.skin_partition.vertex_data]
+                        else:
+                            vertices = geom.data.vertices
+                            normals = geom.data.normals
+                        for vert in vertices:
+                            newvert = vert * diff
+                            vert.x = newvert.x
+                            vert.y = newvert.y
+                            vert.z = newvert.z
+                        diff33 = diff.get_matrix_33()
+                        for norm in normals:
+                            newnorm = norm * diff33
+                            norm.x = newnorm.x
+                            norm.y = newnorm.y
+                            norm.z = newnorm.z
+                        break
+                # store bind pose
+                for bonenode, bonedata in self.bones_iter(skininst):
+                    NifLog.debug(f"Stored {geom.name} bind position")
+                    self.bind_store[bonenode] = self.get_skin_bind(bonedata, geom, n_armature)
 
         NifLog.debug("Storing non-skeletal bone poses")
         self.fix_pose(n_armature, n_armature)
@@ -220,11 +227,12 @@ class Armature:
             self.transform_anim.get_bind_data(b_armature_obj)
 
         for bone_name, b_bone in b_armature_obj.data.bones.items():
-            n_block = self.name_to_block[bone_name]
-            # the property is only available from object mode!
-            block_store.store_longname(b_bone, n_block.name)
-            if NifOp.props.animation:
-                self.transform_anim.import_transforms(n_block, b_armature_obj, bone_name)
+            n_block = self.name_to_block.get(bone_name)
+            if n_block:
+               # the property is only available from object mode!
+                block_store.store_longname(b_bone, n_block.name)
+                if NifOp.props.animation:
+                    self.transform_anim.import_transforms(n_block, b_armature_obj, bone_name)
 
         # import pose
         for b_name, n_block in self.name_to_block.items():
@@ -237,19 +245,12 @@ class Armature:
 
         return b_armature_obj
 
-    def import_bone_bind(self, n_block, b_armature_data, n_armature, b_parent_bone=None):
+    def create_bone(self, bone_name, bind_key, b_armature_data, b_parent_bone=None):
         """Adds a bone to the armature in edit mode."""
-        # check that n_block is indeed a bone
-        if not self.is_bone(n_block):
-            return None
-        # bone name
-        bone_name = block_store.import_name(n_block)
         # create a new bone
         b_edit_bone = b_armature_data.edit_bones.new(bone_name)
-        # store nif block for access from object mode
-        self.name_to_block[b_edit_bone.name] = n_block
         # get the nif bone's armature space matrix (under the hood all bone space matrixes are multiplied together)
-        n_bind = math.nifformat_to_mathutils_matrix(self.bind_store.get(n_block, NifClasses.Matrix44()))
+        n_bind = math.nifformat_to_mathutils_matrix(self.bind_store.get(bind_key, NifClasses.Matrix44()))
         # get transformation in blender's coordinate space
         b_bind = math.nif_bind_to_blender_bind(n_bind)
 
@@ -259,6 +260,24 @@ class Armature:
         # link to parent
         if b_parent_bone:
             b_edit_bone.parent = b_parent_bone
+        return b_edit_bone
+
+    def import_bone_bind(self, n_block, b_armature_data, n_armature, b_parent_bone=None):
+        """Adds a bone to the armature in edit mode."""
+        if isinstance(n_block, NifClasses.NiMesh):
+            # NiMesh has bones, but they are not separate blocks
+            for i, transform in enumerate(n_block.extra_em_data.bone_transforms):
+                bone_name = get_bone_name_for_blender(str(i))
+                b_edit_bone = self.create_bone(bone_name, i, b_armature_data, b_parent_bone)
+            return
+        elif not self.is_bone(n_block):
+            # check that n_block is indeed a bone
+            return None
+        # bone name
+        bone_name = block_store.import_name(n_block)
+        b_edit_bone = self.create_bone(bone_name, n_block, b_armature_data, b_parent_bone)
+        # store nif block for access from object mode
+        self.name_to_block[b_edit_bone.name] = n_block
         # import and parent bone children
         for n_child in n_block.children:
             self.import_bone_bind(n_child, b_armature_data, n_armature, b_edit_bone)
@@ -281,21 +300,28 @@ class Armature:
         """Return the index of the max value in values"""
         return max(zip(values, range(len(values))))[1]
 
-    def get_forward_axis(self, n_bone, axis_indices):
-        """Helper function to get the forward axis of a bone"""
-        # check that n_block is indeed a bone
-        if not self.is_bone(n_bone):
-            return None
-        trans = n_bone.translation.as_tuple()
-        trans_abs = tuple(abs(v) for v in trans)
+    @classmethod
+    def max_coord_ind_from_translation(cls, translation):
+        trans_abs = tuple(abs(v) for v in translation)
         # get the index of the coordinate with the biggest absolute value
-        max_coord_ind = self.argmax(trans_abs)
+        max_coord_ind = cls.argmax(trans_abs)
         # now check the sign
-        actual_value = trans[max_coord_ind]
+        actual_value = translation[max_coord_ind]
         # handle sign accordingly so negative indices map to the negative identifiers in list
         if actual_value < 0:
             max_coord_ind += 3
-        axis_indices.append(max_coord_ind)
+        return max_coord_ind
+
+    def get_forward_axis(self, n_bone, axis_indices):
+        """Helper function to get the forward axis of a bone"""
+        # check that n_block is indeed a bone
+        if isinstance(n_bone, NifClasses.NiMesh):
+            for transform in n_bone.extra_em_data.bone_transforms:
+                axis_indices.append(self.max_coord_ind_from_translation(transform.get_transpose().get_translation()))
+            return
+        elif not self.is_bone(n_bone):
+            return None
+        axis_indices.append(self.max_coord_ind_from_translation(n_bone.translation))
         # move down the hierarchy
         for n_child in n_bone.children:
             self.get_forward_axis(n_child, axis_indices)

--- a/io_scene_niftools/modules/nif_import/constraint/__init__.py
+++ b/io_scene_niftools/modules/nif_import/constraint/__init__.py
@@ -79,33 +79,31 @@ class Constraint:
         # now import all constraints
         for hkconstraint in hkbody.constraints:
 
-            # check constraint entities
-            if not hkconstraint.num_entities == 2:
+            # check constraint 
+            c_info = hkconstraint.constraint_info
+            if not c_info.num_entities == 2:
                 NifLog.warn("Constraint with more than 2 entities, skipped")
                 continue
-            if not hkconstraint.entities[0] is hkbody:
+            if not c_info.entity_a is hkbody:
                 NifLog.warn("First constraint entity not self, skipped")
                 continue
-            if not hkconstraint.entities[1] in collision.DICT_HAVOK_OBJECTS:
+            if not c_info.entity_b in collision.DICT_HAVOK_OBJECTS:
                 NifLog.warn("Second constraint entity not imported, skipped")
                 continue
 
             # get constraint descriptor
-            if isinstance(hkconstraint, NifClasses.BhkRagdollConstraint):
-                hkdescriptor = hkconstraint.ragdoll
+            hkdescriptor = hkconstraint.constraint
+            if isinstance(hkdescriptor, (NifClasses.BhkRagdollConstraintCInfo,
+                                         NifClasses.BhkLimitedHingeConstraintCInfo,
+                                         NifClasses.BhkHingeConstraintCInfo)):
                 b_hkobj.rigid_body.enabled = True
-            elif isinstance(hkconstraint, NifClasses.BhkLimitedHingeConstraint):
-                hkdescriptor = hkconstraint.limited_hinge
-                b_hkobj.rigid_body.enabled = True
-            elif isinstance(hkconstraint, NifClasses.BhkHingeConstraint):
-                hkdescriptor = hkconstraint.hinge
-                b_hkobj.rigid_body.enabled = True
-            elif isinstance(hkconstraint, NifClasses.BhkMalleableConstraint):
-                if hkconstraint.type == 7:
-                    hkdescriptor = hkconstraint.ragdoll
+            elif isinstance(hkdescriptor, NifClasses.BhkMalleableConstraintCInfo):
+                # TODO [constraint] add other types used by malleable constraint (for values 0, 1, 6 and 8)
+                if hkdescriptor.type == 2:
+                    hkdescriptor = hkdescriptor.limited_hinge
                     b_hkobj.rigid_body.enabled = False
-                elif hkconstraint.type == 2:
-                    hkdescriptor = hkconstraint.limited_hinge
+                elif hkdescriptor.type == 7:
+                    hkdescriptor = hkconstraint.ragdoll
                     b_hkobj.rigid_body.enabled = False
                 else:
                     NifLog.warn(f"Unknown malleable type ({hkconstraint.type:s}), skipped")

--- a/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
@@ -49,7 +49,7 @@ from io_scene_niftools.modules.nif_import.property.material import Material
 from io_scene_niftools.modules.nif_import.property.geometry.mesh import MeshPropertyProcessor
 from io_scene_niftools.utils import math
 from io_scene_niftools.utils.singleton import NifOp
-from io_scene_niftools.utils.logging import NifLog
+from io_scene_niftools.utils.logging import NifLog, NifError
 
 
 class Mesh:
@@ -98,6 +98,10 @@ class Mesh:
             if vertex_attributes.normals:
                 normals = [vertex.normal for vertex in vertex_data]
         elif isinstance(n_block, NifClasses.NiMesh):
+            # if it has a displaylist then we don't know how to process this NiMesh
+            if len(n_block.geomdata_by_name("DISPLAYLIST")) > 0:
+                raise NifError(f"Geometry {node_name} contains a DISPLAYLIST-annotated NiDataStream. This is not yet "
+                               f"supported.")
             # get the data from the associated nidatastreams based on the description in the component semantics
             vertices.extend(list(chain.from_iterable(n_block.geomdata_by_name("POSITION"))))
             vertices.extend(list(chain.from_iterable(n_block.geomdata_by_name("POSITION_BP"))))

--- a/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
@@ -85,8 +85,10 @@ class Mesh:
         if isinstance(n_block, NifClasses.BSTriShape):
             vertex_attributes = n_block.vertex_desc.vertex_attributes
             vertex_data = n_block.get_vertex_data()
-            # change this part later for skinned meshes
-            if vertex_attributes.vertex:
+            if isinstance(n_block, NifClasses.BSDynamicTriShape):
+                # for BSDynamicTriShapes, the vertex data is stored in 4-component vertices
+                vertices = [(vertex.x, vertex.y, vertex.z) for vertex in n_block.vertices]
+            elif vertex_attributes.vertex:
                 vertices = [vertex.vertex for vertex in vertex_data]
             triangles = n_block.get_triangles()
             if vertex_attributes.u_vs:

--- a/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
@@ -119,6 +119,9 @@ class Mesh:
                 normals = None
             else:
                 normals = list(chain.from_iterable(normals))
+                # for some reason, normals can be four-component structs instead of 3, discard the 4th.
+                if len(normals[0]) > 3:
+                    normals = [(n[0], n[1], n[2]) for n in normals]
         elif isinstance(n_block, NifClasses.NiTriBasedGeom):
 
             # shortcut for mesh geometry data

--- a/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
@@ -99,7 +99,8 @@ class Mesh:
                 normals = [vertex.normal for vertex in vertex_data]
         elif isinstance(n_block, NifClasses.NiMesh):
             # get the data from the associated nidatastreams based on the description in the component semantics
-            vertices = list(chain.from_iterable(n_block.geomdata_by_name("POSITION")))
+            vertices.extend(list(chain.from_iterable(n_block.geomdata_by_name("POSITION"))))
+            vertices.extend(list(chain.from_iterable(n_block.geomdata_by_name("POSITION_BP"))))
             triangles = n_block.get_triangles()
             uvs = n_block.geomdata_by_name("TEXCOORD")
             if len(uvs) == 0:
@@ -113,6 +114,7 @@ class Mesh:
                 vertex_colors = list(chain.from_iterable(vertex_colors))
                 vertex_colors = [NifClasses.Color4.from_value(color) for color in vertex_colors]
             normals = n_block.geomdata_by_name("NORMAL")
+            normals.extend(n_block.geomdata_by_name("NORMAL_BP"))
             if len(normals) == 0:
                 normals = None
             else:

--- a/io_scene_niftools/modules/nif_import/object/__init__.py
+++ b/io_scene_niftools/modules/nif_import/object/__init__.py
@@ -125,6 +125,9 @@ class Object:
 
         return b_obj
 
+    def has_geometry(self, n_block):
+        return isinstance(n_block, self.mesh.supported_mesh_types)
+
     def import_geometry_object(self, b_armature, n_block):
         # it's a shape node and we're not importing skeleton only
         b_obj = self.create_mesh_object(n_block)
@@ -146,7 +149,7 @@ class Object:
 
         if hasattr(n_block, "data") and isinstance(n_block.data.consistency_flags, NifClasses.ConsistencyType):
             b_obj.niftools.consistency_flags = n_block.data.consistency_flags.name
-        if n_block.is_skin():
+        if n_block.is_skin() and hasattr(n_block, "skin_instance"):
             skininst = n_block.skin_instance
             skelroot = skininst.skeleton_root
             b_obj.niftools.skeleton_root = block_store.import_name(skelroot)

--- a/io_scene_niftools/modules/nif_import/property/geometry/mesh.py
+++ b/io_scene_niftools/modules/nif_import/property/geometry/mesh.py
@@ -69,7 +69,8 @@ class MeshPropertyProcessor:
         b_mesh = b_obj.data
 
         # get all valid properties that are attached to n_block
-        props = list(prop for prop in itertools.chain(n_block.properties, [n_block.shader_property, n_block.alpha_property]) if prop is not None)
+        bs_properties = [getattr(n_block, prop_name, None) for prop_name in ("shader_property", "alpha_property")]
+        props = list(prop for prop in itertools.chain(n_block.properties, bs_properties) if prop is not None)
 
         # we need no material if we have no properties
         if not props:

--- a/io_scene_niftools/modules/nif_import/property/object/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/object/__init__.py
@@ -39,7 +39,6 @@
 import bpy
 from generated.formats.nif import classes as NifClasses
 
-from io_scene_niftools.properties.object import PRN_DICT
 from math import pi
 
 
@@ -59,24 +58,7 @@ class ObjectProperty:
             if isinstance(n_extra, NifClasses.NiStringExtraData):
                 # weapon location or attachment position
                 if n_extra.name == "Prn":
-                    game = bpy.context.scene.niftools_scene.game
-                    if game in PRN_DICT[next(iter(PRN_DICT))]:
-                        # first check specifically in that game
-                        for slot, game_map in PRN_DICT.items():
-                            if game_map[game].lower() == n_extra.string_data.lower():
-                                b_obj.niftools.prn_location = slot
-                                break
-                    if b_obj.niftools.prn_location == "NONE":
-                        # we didn't find anything, either because the game doesn't have it,
-                        # or we have the wrong game. Check all key, value pairs
-                        for slot, game_map in PRN_DICT.items():
-                            for k, v in game_map.items():
-                                if v.lower() == n_extra.string_data.lower():
-                                    b_obj.niftools.prn_location = slot
-                                    break
-                            else:
-                                continue
-                            break
+                    b_obj.niftools.prn_location = n_extra.string_data
                 elif n_extra.name == "UPB":
                     b_obj.niftools.upb = n_extra.string_data
             elif isinstance(n_extra, NifClasses.BSXFlags):

--- a/io_scene_niftools/modules/nif_import/property/object/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/object/__init__.py
@@ -70,7 +70,7 @@ class ObjectProperty:
                         # we didn't find anything, either because the game doesn't have it,
                         # or we have the wrong game. Check all key, value pairs
                         for slot, game_map in PRN_DICT.items():
-                            for k, v in game_map:
+                            for k, v in game_map.items():
                                 if v.lower() == n_extra.string_data.lower():
                                     b_obj.niftools.prn_location = slot
                                     break

--- a/io_scene_niftools/modules/nif_import/property/object/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/object/__init__.py
@@ -51,7 +51,7 @@ class ObjectProperty:
         niftools_scene = bpy.context.scene.niftools_scene
         # store type of root node
         if isinstance(root_block, NifClasses.BSFadeNode):
-            niftools_scene.rootnode = 'BSFadeNode'
+            b_obj.niftools.nodetype = 'BSFadeNode'
         # store its flags
         b_obj.niftools.flags = root_block.flags
         # store extra datas

--- a/io_scene_niftools/nif_export.py
+++ b/io_scene_niftools/nif_export.py
@@ -88,7 +88,7 @@ class NifExport(NifCommon):
         try:  # catch export errors
 
             # protect against null nif versions
-            if bpy.context.scene.niftools_scene.game == 'NONE':
+            if bpy.context.scene.niftools_scene.game == 'UNKNOWN':
                 raise NifError("You have not selected a game. Please select a game and"
                                 " nif version in the scene tab.")
 

--- a/io_scene_niftools/nif_import.py
+++ b/io_scene_niftools/nif_import.py
@@ -155,7 +155,7 @@ class NifImport(NifCommon):
         self.armaturehelper.check_for_skin(root_block)
 
         # read the NIF tree
-        if isinstance(root_block, (NifClasses.NiNode, NifClasses.NiTriBasedGeom, NifClasses.BSTriShape)):
+        if isinstance(root_block, NifClasses.NiNode) or self.object_helper.has_geometry(root_block):
             b_obj = self.import_branch(root_block)
             ObjectProperty().import_extra_datas(root_block, b_obj)
 
@@ -196,7 +196,7 @@ class NifImport(NifCommon):
             return None
 
         NifLog.info(f"Importing data for block '{n_block.name}'")
-        if isinstance(n_block, (NifClasses.NiTriBasedGeom, NifClasses.BSTriShape)) and NifOp.props.process != "SKELETON_ONLY":
+        if self.objecthelper.has_geometry(n_block) and NifOp.props.process != "SKELETON_ONLY":
             return self.objecthelper.import_geometry_object(b_armature, n_block)
 
         elif isinstance(n_block, NifClasses.NiNode):

--- a/io_scene_niftools/nif_import.py
+++ b/io_scene_niftools/nif_import.py
@@ -155,7 +155,7 @@ class NifImport(NifCommon):
         self.armaturehelper.check_for_skin(root_block)
 
         # read the NIF tree
-        if isinstance(root_block, NifClasses.NiNode) or self.object_helper.has_geometry(root_block):
+        if isinstance(root_block, NifClasses.NiNode) or self.objecthelper.has_geometry(root_block):
             b_obj = self.import_branch(root_block)
             ObjectProperty().import_extra_datas(root_block, b_obj)
 

--- a/io_scene_niftools/operators/common_op.py
+++ b/io_scene_niftools/operators/common_op.py
@@ -37,7 +37,13 @@
 #
 # ***** END LICENSE BLOCK *****
 import bpy
+from itertools import chain
 
+from generated.formats.nif.versions import available_versions
+
+
+nif_extensions = list(set(chain.from_iterable([version.ext for version in available_versions if version.supported])))
+nif_glob = "*.jmi" + (f";*.{';*.'.join(nif_extensions)}" if nif_extensions else '')
 
 class CommonDevOperator:
     """Abstract base class for import and export user interface."""
@@ -106,7 +112,7 @@ class CommonNif:
 
     # File name filter for file select dialog.
     filter_glob: bpy.props.StringProperty(
-        default="*.nif;*.item;*.nifcache;*.jmi",
+        default=nif_glob,
         options={'HIDDEN'})
 
 

--- a/io_scene_niftools/properties/collision.py
+++ b/io_scene_niftools/properties/collision.py
@@ -58,7 +58,7 @@ def game_specific_col_layer_items(self, context):
     else:
         current_game = context.scene.niftools_scene.game
     col_layer_format = None
-    if current_game == "OBLIVION":
+    if current_game in ("OBLIVION", "OBLIVION_KF"):
         col_layer_format = NifClasses.OblivionLayer
     elif current_game == "FALLOUT_3":
         col_layer_format = NifClasses.Fallout3Layer

--- a/io_scene_niftools/properties/object.py
+++ b/io_scene_niftools/properties/object.py
@@ -52,25 +52,30 @@ from generated.formats.nif import classes as NifClasses
 from io_scene_niftools.utils.decorators import register_classes, unregister_classes
 
 
-prn_array = [
-            ["OBLIVION", "FALLOUT_3", "SKYRIM"],
-            ["DAGGER", "SideWeapon", "Weapon", "WeaponDagger"],
-            ["2HANDED", "BackWeapon", "Weapon", "WeaponBack"],
-            ["BOW", "BackWeapon", None, "WeaponBow"],
-            ["MACE", "SideWeapon", "Weapon", "WeaponMace"],
-            ["SHIELD", "Bip01 L ForearmTwist", None, "SHIELD"],
-            ["STAFF", "Torch", "Weapon", "WeaponStaff"],
-            ["SWORD", "SideWeapon", "Weapon", "WeaponSword"],
-            ["AXE", "SideWeapon", "Weapon", "WeaponAxe"],
-            ["QUIVER", "Quiver", "Weapon", "QUIVER"],
-            ["TORCH", "Torch", "Weapon", "SHIELD"],
-            ["HELMET", "Bip01 Head", "Bip01 Head", "NPC Head [Head]"],
-            ["RING", "Bip01 R Finger1", "Bip01 R Finger1", "NPC R Finger10 [RF10]"]
-            ]
-# PRN_DICT is a dict like so: dict['SLOT']['GAME']: 'Bone'
-PRN_DICT = {}
-for row in prn_array[1:]:
-    PRN_DICT[row[0]] = dict(zip(prn_array[0], row[1:]))
+prn_map = {"OBLIVION":   [("SideWeapon", ""),
+                          ("BackWeapon", ""),
+                          ("Bip01 L ForearmTwist", "Used for shields"),
+                          ("Torch", ""),
+                          ("Quiver", ""),
+                          ("Bip01 Head", "Used for helmets"),
+                          ("Bip01 R Finger1", "Used for rings")],
+           "FALLOUT_3":  [("Weapon", ""),
+                          ("Bip01 Head", "Used for helmets"),
+                          ("Bip01 R Finger1", "")],
+           "SKYRIM":     [("WeaponDagger", ""),
+                          ("WeaponBack", ""),
+                          ("WeaponBow", ""),
+                          ("WeaponMace", ""),
+                          ("SHIELD", ""),
+                          ("WeaponStaff", ""),
+                          ("WeaponSword", ""),
+                          ("WeaponAxe", ""),
+                          ("QUIVER", ""),
+                          ("SHIELD", ""),
+                          ("NPC Head [Head]", "Used for helmets"),
+                          ("NPC R Finger10 [RF10]", "Used for rings")]
+           }
+prn_map["SKYRIM_SE"] = prn_map["SKYRIM"]
 
 
 class ExtraData(PropertyGroup):
@@ -142,10 +147,10 @@ class ObjectProperty(PropertyGroup):
         default='NiNode',
     )
 
-    prn_location: EnumProperty(
+    prn_location: StringProperty(
         name='Weapon Location',
         description='Attachment point of weapon, for Skyrim, FO3 & Oblivion',
-        items=[(item, item, "", i) for i, item in enumerate(["NONE"] + list(PRN_DICT.keys()))],
+        search=lambda self, context, edit_text: prn_map.get(context.scene.niftools_scene.game, []),
         # default = 'NONE'
     )
 

--- a/io_scene_niftools/properties/object.py
+++ b/io_scene_niftools/properties/object.py
@@ -133,6 +133,15 @@ class BsInventoryMarker(PropertyGroup):
 
 class ObjectProperty(PropertyGroup):
 
+    nodetype: EnumProperty(
+        name='Node Type',
+        description='Type of node this empty represents',
+        items=(
+              ('NiNode', 'NiNode', "", 0),
+              ('BSFadeNode', 'BSFadeNode', "", 1)),
+        default='NiNode',
+    )
+
     prn_location: EnumProperty(
         name='Weapon Location',
         description='Attachment point of weapon, for Skyrim, FO3 & Oblivion',

--- a/io_scene_niftools/properties/scene.py
+++ b/io_scene_niftools/properties/scene.py
@@ -70,7 +70,7 @@ def populate_version_map(iterable, version_map):
 
 populate_version_map(primary_games, game_version_map)
 populate_version_map(all_games, game_version_map)
-game_version_map["NONE"] = (0, 0, 0)
+game_version_map["UNKNOWN"] = (0, 0, 0)
 
 # noinspection PyUnusedLocal
 def update_version_from_game(self, context):
@@ -98,14 +98,14 @@ class Scene(PropertyGroup):
 
     # For which game to export.
     game: bpy.props.EnumProperty(
-        items=[('NONE', 'NONE', 'No game selected')] + [
+        items=[('UNKNOWN', 'UNKNOWN', 'No game selected')] + [
             (member.name, member.value, "Export for " + member.value)
             for member in sorted(
                 [member for member in set(all_games)], key=lambda x: x.name)
         ],
         name="Game",
         description="For which game to export",
-        default='NONE',
+        default='UNKNOWN',
         update=update_version_from_game)
 
     scale_correction: bpy.props.FloatProperty(

--- a/io_scene_niftools/properties/scene.py
+++ b/io_scene_niftools/properties/scene.py
@@ -108,15 +108,6 @@ class Scene(PropertyGroup):
         default='NONE',
         update=update_version_from_game)
 
-    rootnode: EnumProperty(
-        name='Root Node',
-        description='Type of property used to display meshes',
-        items=(
-            ('NiNode', 'NiNode', "", 0),
-            ('BSFadeNode', 'BSFadeNode', "", 1)),
-        default='NiNode',
-    )
-
     scale_correction: bpy.props.FloatProperty(
         name="Scale Correction",
         description="Changes size of mesh to fit onto Blender's default grid",

--- a/io_scene_niftools/properties/shader.py
+++ b/io_scene_niftools/properties/shader.py
@@ -88,15 +88,12 @@ def prettify_prop_name(property_name):
 
 annotations_dict = ShaderProps.__dict__.get('__annotations__', None)
 if annotations_dict:
-    for property_name in NifClasses.BSShaderFlags.__members__:
-        if property_name not in annotations_dict:
-            annotations_dict[property_name] = BoolProperty(name=prettify_prop_name(property_name[3:]))
-    for property_name in NifClasses.SkyrimShaderPropertyFlags1.__members__:
-        if property_name not in annotations_dict:
-            annotations_dict[property_name] = BoolProperty(name=prettify_prop_name(property_name[7:]))
-    for property_name in NifClasses.SkyrimShaderPropertyFlags2.__members__:
-        if property_name not in annotations_dict:
-            annotations_dict[property_name] = BoolProperty(name=prettify_prop_name(property_name[7:]))
+    for flag_field in (NifClasses.BSShaderFlags,
+                       NifClasses.SkyrimShaderPropertyFlags1,
+                       NifClasses.SkyrimShaderPropertyFlags2):
+        for property_name in flag_field.__members__:
+            if property_name not in annotations_dict:
+                annotations_dict[property_name] = BoolProperty(name=prettify_prop_name(property_name))
 
 
 CLASSES = [

--- a/io_scene_niftools/ui/object.py
+++ b/io_scene_niftools/ui/object.py
@@ -46,7 +46,10 @@ class ObjectButtonsPanel(Panel):
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
     bl_context = "object"
-    
+
+    @staticmethod
+    def is_root_object(b_obj):
+        return b_obj.parent is None
 
 class ObjectPanel(ObjectButtonsPanel):
     bl_label = "Niftools Object Property"
@@ -58,19 +61,24 @@ class ObjectPanel(ObjectButtonsPanel):
         return True
 
     def draw(self, context):
-        ob = context.object
-        nif_obj_props = ob.niftools
+        b_obj = context.object
+        nif_obj_props = b_obj.niftools
 
         layout = self.layout
         row = layout.column()
-        row.prop(nif_obj_props, "prn_location")
-        row.prop(nif_obj_props, "upb")
-        row.prop(nif_obj_props, "bsxflags")
-        row.prop(nif_obj_props, "consistency_flags")
+        if self.is_root_object(b_obj):
+            if b_obj.type == "EMPTY":
+                row.prop(nif_obj_props, "nodetype")
+            row.prop(nif_obj_props, "prn_location")
+            row.prop(nif_obj_props, "upb")
+            row.prop(nif_obj_props, "bsxflags")
+        if b_obj.type == "MESH":
+            # consistency flags only exist for NiGeometry
+            row.prop(nif_obj_props, "consistency_flags")
         row.prop(nif_obj_props, "flags")
         row.prop(nif_obj_props, "longname")
 
-        parent = ob.parent
+        parent = b_obj.parent
         if parent and parent.type == 'ARMATURE':
             row.prop_search(nif_obj_props, "skeleton_root", parent.data, "bones")
 
@@ -144,7 +152,7 @@ class ObjectBSInvMarkerPanel(ObjectButtonsPanel):
     # noinspection PyUnusedLocal
     @classmethod
     def poll(cls, context):
-        return True
+        return cls.is_root_object(context.object)
 
     def draw(self, context):
         layout = self.layout

--- a/io_scene_niftools/ui/object.py
+++ b/io_scene_niftools/ui/object.py
@@ -69,7 +69,9 @@ class ObjectPanel(ObjectButtonsPanel):
         if self.is_root_object(b_obj):
             if b_obj.type == "EMPTY":
                 row.prop(nif_obj_props, "nodetype")
-            row.prop(nif_obj_props, "prn_location")
+            if b_obj.type != "ARMATURE":
+                # prn nistringextradata is only useful as replacement for rigging data
+                row.prop(nif_obj_props, "prn_location")
             row.prop(nif_obj_props, "upb")
             row.prop(nif_obj_props, "bsxflags")
         if b_obj.type == "MESH":

--- a/io_scene_niftools/ui/scene.py
+++ b/io_scene_niftools/ui/scene.py
@@ -65,7 +65,6 @@ class ScenePanel(SceneButtonsPanel):
         layout = self.layout
         row = layout.column()
         row.prop(nif_scene_props, "game")
-        row.prop(nif_scene_props, "rootnode")
 
 
 class SceneVersionInfoPanel(SceneButtonsPanel):

--- a/io_scene_niftools/ui/shader.py
+++ b/io_scene_niftools/ui/shader.py
@@ -69,15 +69,15 @@ class ShaderPanel(Panel):
         if nif_obj_props.bs_shadertype == 'BSShaderPPLightingProperty':
             row.prop(nif_obj_props, "bsspplp_shaderobjtype")
 
-            for property_name in sorted([member.name for member in NifClasses.BSShaderFlags]):
+            for property_name in sorted(NifClasses.BSShaderFlags.__members__):
                 row.prop(nif_obj_props, property_name)
 
         elif nif_obj_props.bs_shadertype in ('BSLightingShaderProperty', 'BSEffectShaderProperty'):
             row.prop(nif_obj_props, "bslsp_shaderobjtype")
 
-            for property_name in sorted([member.name for member in NifClasses.SkyrimShaderPropertyFlags1]):
+            for property_name in sorted(NifClasses.SkyrimShaderPropertyFlags1.__members__):
                 row.prop(nif_obj_props, property_name)
-            for property_name in sorted([member.name for member in NifClasses.SkyrimShaderPropertyFlags2]):
+            for property_name in sorted(NifClasses.SkyrimShaderPropertyFlags2.__members__):
                 row.prop(nif_obj_props, property_name)
 
 


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
1. Updates to constraint import.
2. Made Nif file glob partially dependent on the xml-generated extensions.
3. Added support for imports of NiMeshes.
   1. Support for regular NiMesh import and Epic Mickey (2) NiMesh import.
   2. Support for weighted NiMeshes.
4. Updates to collision export.
5. Support for import of BSDynamicTriShape.
6. Update to Object properties ui.
7. Moved node type to use for the root node back to object.

##  Detailed Description
1. Constraint import needed to be updated due to xml changes - the most of the constraint information is now stored in an info struct in the constraint block, rather than the block itself. The update only changed some of the syntax to agree with the xml, I have no idea how functional constraint import actually is at the moment.
2. The file glob used by Blender's import/export screen for nifs is now dynamically constructed from the version objects in the nif versions module, which should store all non-nif/kf extensions used by those versions. In practice this isn't exactly the case so there is still some hardcoding.
3. -
   1. Importing the geometry is relatively simple and relies on specific names associated with the datastreams. Mixing of POSITION and POSITION_BP is not supported with the current code, but I have no indication that this actually occurs - or indeed that for any name other than TEXCOORD there are multiple.
   2. The armature import can be classed in two different cases: regular, or epic mickey. In the regular case, weight information is stored in the same manner as geometry information, and bone rest position information is stored in the NiSkinningModifier. In the epic mickey case there is no pose information, weight information and the bone rest positions are stored in the extra_em_data struct. I've somewhat crudely injected code into the existing armature handler to extract the correct information, but there might be better or more elegant ways of handling this.
4. Mostly changes to reflect the newer xml, as well as removing some setting of fields because they are unused or already set correctly because of their defaults.
5. BSDynamicTriShape identical to BSTriShape, except for one part: it stores its vertex information in a separate vertices field with Vector4, rather than as a Vector3 in the Vertex Data field. This causes means some special cases for BSDynamicTriShape in the BSTriShape paths.
6. Some properties were made conditionally accessible in the ui because they are only really used for root objects - i.e. those with no parents.
7. This already used to be the case. It was previously moved to scene, but this isn't consistent with how the rest of the object properties are handled (e.g. Prn or BSInvMarker).

## Fixes Known Issues
1. #533
2. #421 (only import, and can't check because the nif isn't available anymore)
3. #407

## Documentation
**[Overview of updates to documentation]**

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
