### PR TITLE
Use "Color" type for "InvertY" group

### DIFF
--- a/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_niftools/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -300,9 +300,9 @@ class NodesWrapper:
             group_nodes = node_group.nodes
             # add the in/output nodes
             input_node = group_nodes.new('NodeGroupInput')
-            node_group.inputs.new('NodeSocketImage', "Input")
+            node_group.inputs.new('NodeSocketColor', "Input")
             output_node = group_nodes.new('NodeGroupOutput')
-            node_group.outputs.new('NodeSocketImage', "Output")
+            node_group.outputs.new('NodeSocketColor', "Output")
             # create the converting nodes
             separate_node = group_nodes.new("ShaderNodeSeparateRGB")
             invert_node = group_nodes.new("ShaderNodeInvert")


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
Use [```NodeSocketColor```](https://docs.blender.org/api/latest/bpy.types.NodeSocketColor.html) for ```InvertY``` group for normal maps.

##  Detailed Description
Eevee is okay but Cycles renderer is not happy if ```NodeSocketImage``` is used. Also blender GUI won't allow you to set ```NodeSocketImage``` as a socket type.

## Fixes Known Issues
**[Ordered list of issues fixed by this PR]**

## Documentation
**[Overview of updates to documentation]**

## Testing
Blender 3.3.1 Windows

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
