### PR TITLE
Use docker to generate the new-pyffi code for installation/make zip

### DIFF
--- a/install/.gitignore
+++ b/install/.gitignore
@@ -1,2 +1,3 @@
 # Ignore any generated files
 temp/
+*.zip

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -5,12 +5,12 @@ ARG pyffi_commit=4b18387137a4e73386f020fff66d033354ab2186
 ARG nifxml_commit=89d03ffe69254ef4b3b58b0a22ec2ff9820b2e63
 
 WORKDIR /codegen
-RUN git clone https://github.com/OpenNaja/cobra-tools.git && cd cobra-tools && git reset --hard $cobra_commit && cd .. && \
-    git clone https://github.com/Candoran2/new-pyffi && cd new-pyffi && git reset --hard $pyffi_commit && cd .. && \
+RUN git clone https://github.com/OpenNaja/cobra-tools.git && cd cobra-tools && git reset --hard $cobra_commit && cd ..
+RUN git clone https://github.com/Candoran2/new-pyffi && cd new-pyffi && git reset --hard $pyffi_commit && cd .. && \
     mv ./new-pyffi/formats/nif ./cobra-tools/source/formats && \
     mv ./new-pyffi/spells ./cobra-tools/source && \
-    mv ./new-pyffi/utils ./cobra-tools/source && \
-    git clone https://github.com/niftools/nifxml.git && cd nifxml && git reset --hard $nifxml_commit && cd .. && \
+    mv ./new-pyffi/utils ./cobra-tools/source
+RUN git clone https://github.com/niftools/nifxml.git && cd nifxml && git reset --hard $nifxml_commit && cd .. && \
     mv ./nifxml/nif.xml ./cobra-tools/source/formats/nif
 
 WORKDIR cobra-tools

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -1,11 +1,17 @@
 FROM python:3.10.8
 
+ARG cobra_commit=117d0983848468747dd3c7ab0699b230347b1db5
+ARG pyffi_commit=4b18387137a4e73386f020fff66d033354ab2186
+ARG nifxml_commit=89d03ffe69254ef4b3b58b0a22ec2ff9820b2e63
+
 WORKDIR /codegen
-RUN git clone https://github.com/OpenNaja/cobra-tools.git && \
-    git clone https://github.com/Candoran2/new-pyffi && \
+RUN git clone https://github.com/OpenNaja/cobra-tools.git && cd cobra-tools && git reset --hard $cobra_commit && cd .. && \
+    git clone https://github.com/Candoran2/new-pyffi && cd new-pyffi && git reset --hard $pyffi_commit && cd .. && \
     mv ./new-pyffi/formats/nif ./cobra-tools/source/formats && \
     mv ./new-pyffi/spells ./cobra-tools/source && \
-    mv ./new-pyffi/utils ./cobra-tools/utils
+    mv ./new-pyffi/utils ./cobra-tools/utils && \
+    git clone https://github.com/niftools/nifxml.git && cd nifxml && git reset --hard $nifxml_commit && cd .. && \
+    mv ./nifxml/nif.xml ./cobra-tools/source/formats/nif
 
 WORKDIR cobra-tools
 RUN python3 -m pip install --upgrade pip setuptools && \

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -9,7 +9,7 @@ RUN git clone https://github.com/OpenNaja/cobra-tools.git && cd cobra-tools && g
     git clone https://github.com/Candoran2/new-pyffi && cd new-pyffi && git reset --hard $pyffi_commit && cd .. && \
     mv ./new-pyffi/formats/nif ./cobra-tools/source/formats && \
     mv ./new-pyffi/spells ./cobra-tools/source && \
-    mv ./new-pyffi/utils ./cobra-tools/utils && \
+    mv ./new-pyffi/utils ./cobra-tools/source && \
     git clone https://github.com/niftools/nifxml.git && cd nifxml && git reset --hard $nifxml_commit && cd .. && \
     mv ./nifxml/nif.xml ./cobra-tools/source/formats/nif
 

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.10.8
+
+WORKDIR /codegen
+RUN git clone https://github.com/OpenNaja/cobra-tools.git && \
+    git clone https://github.com/Candoran2/new-pyffi && \
+    mv ./new-pyffi/formats/nif ./cobra-tools/source/formats && \
+    mv ./new-pyffi/spells ./cobra-tools/source && \
+    mv ./new-pyffi/utils ./cobra-tools/utils
+
+WORKDIR cobra-tools
+RUN python3 -m pip install --upgrade pip setuptools && \
+    python3 -m pip install -r requirements.txt
+
+ADD generate.sh .
+CMD ["./generate.sh"]

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.9"
+
+services:
+  codegen:
+    build: .
+    volumes:
+      - ./temp/io_scene_niftools/dependencies:/output

--- a/install/generate.sh
+++ b/install/generate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+python3 codegen.py
+mv /codegen/cobra-tools/generated /output
+# TODO: only move the formats we need to reduce bloat
+echo "Done"
+exit

--- a/install/generate.sh
+++ b/install/generate.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
 python3 codegen.py
-mv /codegen/cobra-tools/generated /output
-# TODO: only move the formats we need to reduce bloat
+rm -r /output/*
+mkdir -p /output/generated/formats
+cd /codegen/cobra-tools/generated || exit 1
+# Everything is ~4.3MB while just taking the formats we need is just ~2.8MB
+mv ./formats/base /output/generated/formats
+mv ./formats/dds /output/generated/formats
+mv ./formats/nif /output/generated/formats
+mv ./spells /output/generated
+mv ./utils /output/generated
 echo "Done"
 exit

--- a/install/makezip.bat
+++ b/install/makezip.bat
@@ -25,6 +25,7 @@ xcopy /s "%ROOT%\io_scene_niftools" io_scene_niftools
 mkdir "%DEPS%"
 
 python -m pip install "PyFFI==%PYFFI_VERSION%" --target="%DEPS%"
+docker compose up
 
 xcopy "%ROOT%"\AUTHORS.rst io_scene_niftools
 xcopy "%ROOT%"\CHANGELOG.rst io_scene_niftools

--- a/install/makezip.bat
+++ b/install/makezip.bat
@@ -25,7 +25,7 @@ xcopy /s "%ROOT%\io_scene_niftools" io_scene_niftools
 mkdir "%DEPS%"
 
 python -m pip install "PyFFI==%PYFFI_VERSION%" --target="%DEPS%"
-docker compose up
+docker compose up || exit 1
 
 xcopy "%ROOT%"\AUTHORS.rst io_scene_niftools
 xcopy "%ROOT%"\CHANGELOG.rst io_scene_niftools

--- a/install/makezip.sh
+++ b/install/makezip.sh
@@ -32,7 +32,7 @@ cp -r "${ADDON_IN}" "${ADDON_OUT}"
 echo "Creating dependencies folder ${DEPS_OUT:-${BUILD_DIR}/dependencies}"
 #python -m pip install -i https://test.pypi.org/simple/ PyFFI==2.2.4.dev5 --target="${DEPS_OUT:-${BUILD_DIR}/dependencies}"
 python -m pip install "PyFFI==${PYFFI_VERSION}" --target="${DEPS_OUT:-${BUILD_DIR}/dependencies}"
-docker compose up
+docker compose up || exit 1
 
 echo "Copying loose files"
 cp "${ROOT}"/AUTHORS.rst "${ADDON_OUT}"

--- a/install/makezip.sh
+++ b/install/makezip.sh
@@ -32,6 +32,7 @@ cp -r "${ADDON_IN}" "${ADDON_OUT}"
 echo "Creating dependencies folder ${DEPS_OUT:-${BUILD_DIR}/dependencies}"
 #python -m pip install -i https://test.pypi.org/simple/ PyFFI==2.2.4.dev5 --target="${DEPS_OUT:-${BUILD_DIR}/dependencies}"
 python -m pip install "PyFFI==${PYFFI_VERSION}" --target="${DEPS_OUT:-${BUILD_DIR}/dependencies}"
+docker compose up
 
 echo "Copying loose files"
 cp "${ROOT}"/AUTHORS.rst "${ADDON_OUT}"


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
This pull request uses docker to use cobra-tools and new-pyffi to generate the code required by the blender addon to be functional.

### Manual
Simply run `install/makezip.(bat|sh)` to test

## Additional Information
You will require docker to run these
