### PR TITLE
Extra development of NiMesh import and some fixes

### DIFF
--- a/io_scene_niftools/modules/nif_export/animation/morph.py
+++ b/io_scene_niftools/modules/nif_export/animation/morph.py
@@ -140,6 +140,7 @@ class MorphAnimation(Animation):
             # create interpolator for shape b_key (needs to be there even if there is no fcu)
             interpol = block_store.create_block("NiFloatInterpolator")
             interpol.value = 0
+            # [TODO] condition this - only qualifying fields will have been reset to the correct size
             morph_ctrl.interpolators[key_block_num] = interpol
 
             # fallout 3 stores interpolators inside the interpolator_weights block

--- a/io_scene_niftools/modules/nif_export/collision/havok.py
+++ b/io_scene_niftools/modules/nif_export/collision/havok.py
@@ -465,7 +465,7 @@ class BhkCollision(Collision):
         transform = math.get_object_bind(b_obj)
         rotation = transform.decompose()[1]
 
-        vertices = [vert.co @ transform for vert in b_mesh.vertices]
+        vertices = [transform @ vert.co for vert in b_mesh.vertices]
         triangles = []
         normals = []
         for face in b_mesh.polygons:

--- a/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_export/geometry/mesh/__init__.py
@@ -451,7 +451,7 @@ class Mesh:
         for n_v, b_v in zip(n_geom.data.vertex_colors, vertex_colors):
             n_v.r, n_v.g, n_v.b, n_v.a = b_v
         # uv_sets
-        if bpy.context.scene.niftools_scene.game == "SKYRIM":
+        if bpy.context.scene.niftools_scene.nif_version == 0x14020007 and bpy.context.scene.niftools_scene.user_version_2:
             data_flags = n_geom.data.bs_data_flags
         else:
             data_flags = n_geom.data.data_flags

--- a/io_scene_niftools/modules/nif_export/property/object/__init__.py
+++ b/io_scene_niftools/modules/nif_export/property/object/__init__.py
@@ -226,10 +226,10 @@ class ObjectDataProperty:
         if niftools_scene.game in ('SKYRIM',) and bs_inv_store:
             bs_inv = bs_inv_store[0]
             n_bs_inv_marker = NifClasses.BSInvMarker(n_root.context)
-            n_bs_inv_marker.name = bs_inv.name.encode()
-            n_bs_inv_marker.rotation_x = (-bs_inv.x % (2 * pi)) * 1000
-            n_bs_inv_marker.rotation_y = (-bs_inv.y % (2 * pi)) * 1000
-            n_bs_inv_marker.rotation_z = (-bs_inv.z % (2 * pi)) * 1000
+            n_bs_inv_marker.name = bs_inv.name
+            n_bs_inv_marker.rotation_x = round((-bs_inv.x % (2 * pi)) * 1000)
+            n_bs_inv_marker.rotation_y = round((-bs_inv.y % (2 * pi)) * 1000)
+            n_bs_inv_marker.rotation_z = round((-bs_inv.z % (2 * pi)) * 1000)
             n_bs_inv_marker.zoom = bs_inv.zoom
             n_root.add_extra_data(n_bs_inv_marker)
 

--- a/io_scene_niftools/modules/nif_import/constraint/__init__.py
+++ b/io_scene_niftools/modules/nif_import/constraint/__init__.py
@@ -103,7 +103,7 @@ class Constraint:
                     hkdescriptor = hkdescriptor.limited_hinge
                     b_hkobj.rigid_body.enabled = False
                 elif hkdescriptor.type == 7:
-                    hkdescriptor = hkconstraint.ragdoll
+                    hkdescriptor = hkdescriptor.ragdoll
                     b_hkobj.rigid_body.enabled = False
                 else:
                     NifLog.warn(f"Unknown malleable type ({hkconstraint.type:s}), skipped")

--- a/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
@@ -36,8 +36,6 @@
 #
 # ***** END LICENSE BLOCK *****
 
-from itertools import chain
-
 from generated.formats.nif import classes as NifClasses
 
 import io_scene_niftools.utils.logging
@@ -103,26 +101,24 @@ class Mesh:
                 raise NifError(f"Geometry {node_name} contains a DISPLAYLIST-annotated NiDataStream. This is not yet "
                                f"supported.")
             # get the data from the associated nidatastreams based on the description in the component semantics
-            vertices.extend(list(chain.from_iterable(n_block.geomdata_by_name("POSITION"))))
-            vertices.extend(list(chain.from_iterable(n_block.geomdata_by_name("POSITION_BP"))))
+            vertices.extend(n_block.geomdata_by_name("POSITION", sep_datastreams=False))
+            vertices.extend(n_block.geomdata_by_name("POSITION_BP", sep_datastreams=False))
             triangles = n_block.get_triangles()
             uvs = n_block.geomdata_by_name("TEXCOORD")
             if len(uvs) == 0:
                 uvs = None
             else:
                 uvs = [[NifClasses.TexCoord.from_value(tex_coord) for tex_coord in uv_coords] for uv_coords in uvs]
-            vertex_colors = n_block.geomdata_by_name("COLOR")
+            vertex_colors = n_block.geomdata_by_name("COLOR", sep_datastreams=False)
             if len(vertex_colors) == 0:
                 vertex_colors = None
             else:
-                vertex_colors = list(chain.from_iterable(vertex_colors))
                 vertex_colors = [NifClasses.Color4.from_value(color) for color in vertex_colors]
-            normals = n_block.geomdata_by_name("NORMAL")
-            normals.extend(n_block.geomdata_by_name("NORMAL_BP"))
+            normals = n_block.geomdata_by_name("NORMAL", sep_datastreams=False)
+            normals.extend(n_block.geomdata_by_name("NORMAL_BP", sep_datastreams=False))
             if len(normals) == 0:
                 normals = None
             else:
-                normals = list(chain.from_iterable(normals))
                 # for some reason, normals can be four-component structs instead of 3, discard the 4th.
                 if len(normals[0]) > 3:
                     normals = [(n[0], n[1], n[2]) for n in normals]

--- a/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
+++ b/io_scene_niftools/modules/nif_import/geometry/mesh/__init__.py
@@ -37,6 +37,7 @@
 # ***** END LICENSE BLOCK *****
 
 from generated.formats.nif import classes as NifClasses
+from generated.formats.nif.nimesh.structs.DisplayList import DisplayList
 
 import io_scene_niftools.utils.logging
 from io_scene_niftools.modules.nif_import.animation.morph import MorphAnimation
@@ -97,31 +98,37 @@ class Mesh:
                 normals = [vertex.normal for vertex in vertex_data]
         elif isinstance(n_block, NifClasses.NiMesh):
             # if it has a displaylist then we don't know how to process this NiMesh
-            if len(n_block.geomdata_by_name("DISPLAYLIST")) > 0:
-                raise NifError(f"Geometry {node_name} contains a DISPLAYLIST-annotated NiDataStream. This is not yet "
-                               f"supported.")
-            # get the data from the associated nidatastreams based on the description in the component semantics
-            vertices.extend(n_block.geomdata_by_name("POSITION", sep_datastreams=False))
-            vertices.extend(n_block.geomdata_by_name("POSITION_BP", sep_datastreams=False))
-            triangles = n_block.get_triangles()
-            uvs = n_block.geomdata_by_name("TEXCOORD")
-            if len(uvs) == 0:
-                uvs = None
+            displaylist_data = n_block.geomdata_by_name("DISPLAYLIST", False, False)
+            if len(displaylist_data) > 0:
+                displaylist = DisplayList(displaylist_data)
+                vertices_info, triangles = displaylist.create_mesh_data(n_block)
+                vertices = vertices_info[0]
+                normals = vertices_info[1]
+                vertex_colors = [NifClasses.Color4.from_value(color) for color in vertices_info[2]]
+                uvs = [[NifClasses.TexCoord.from_value(tex_coord) for tex_coord in vertices_info[3]]]
             else:
-                uvs = [[NifClasses.TexCoord.from_value(tex_coord) for tex_coord in uv_coords] for uv_coords in uvs]
-            vertex_colors = n_block.geomdata_by_name("COLOR", sep_datastreams=False)
-            if len(vertex_colors) == 0:
-                vertex_colors = None
-            else:
-                vertex_colors = [NifClasses.Color4.from_value(color) for color in vertex_colors]
-            normals = n_block.geomdata_by_name("NORMAL", sep_datastreams=False)
-            normals.extend(n_block.geomdata_by_name("NORMAL_BP", sep_datastreams=False))
-            if len(normals) == 0:
-                normals = None
-            else:
-                # for some reason, normals can be four-component structs instead of 3, discard the 4th.
-                if len(normals[0]) > 3:
-                    normals = [(n[0], n[1], n[2]) for n in normals]
+                # get the data from the associated nidatastreams based on the description in the component semantics
+                vertices.extend(n_block.geomdata_by_name("POSITION", sep_datastreams=False))
+                vertices.extend(n_block.geomdata_by_name("POSITION_BP", sep_datastreams=False))
+                triangles = n_block.get_triangles()
+                uvs = n_block.geomdata_by_name("TEXCOORD")
+                if len(uvs) == 0:
+                    uvs = None
+                else:
+                    uvs = [[NifClasses.TexCoord.from_value(tex_coord) for tex_coord in uv_coords] for uv_coords in uvs]
+                vertex_colors = n_block.geomdata_by_name("COLOR", sep_datastreams=False)
+                if len(vertex_colors) == 0:
+                    vertex_colors = None
+                else:
+                    vertex_colors = [NifClasses.Color4.from_value(color) for color in vertex_colors]
+                normals = n_block.geomdata_by_name("NORMAL", sep_datastreams=False)
+                normals.extend(n_block.geomdata_by_name("NORMAL_BP", sep_datastreams=False))
+                if len(normals) == 0:
+                    normals = None
+                else:
+                    # for some reason, normals can be four-component structs instead of 3, discard the 4th.
+                    if len(normals[0]) > 3:
+                        normals = [(n[0], n[1], n[2]) for n in normals]
         elif isinstance(n_block, NifClasses.NiTriBasedGeom):
 
             # shortcut for mesh geometry data

--- a/io_scene_niftools/modules/nif_import/geometry/vertex/groups.py
+++ b/io_scene_niftools/modules/nif_import/geometry/vertex/groups.py
@@ -146,8 +146,8 @@ class VertexGroup:
                 skin_modifier = [block for block in ni_block.modifiers if isinstance(block, NifClasses.NiSkinningMeshModifier)][0]
                 bone_names = [block_store.import_name(bone) for bone in skin_modifier.bones]
 
-                bone_palettes = ni_block.geomdata_by_name('BONE_PALETTE')
-                bone_index_datas = ni_block.geomdata_by_name('BLENDINDICES')
+                bone_palettes = ni_block.geomdata_by_name('BONE_PALETTE', sep_datastreams=False, sep_regions=True)
+                bone_index_datas = ni_block.geomdata_by_name('BLENDINDICES', sep_datastreams=False, sep_regions=True)
 
                 for palette, index_datas in zip(bone_palettes, bone_index_datas):
                     bone_indices.extend([[palette[i] for i in indices] for indices in index_datas])

--- a/io_scene_niftools/properties/object.py
+++ b/io_scene_niftools/properties/object.py
@@ -136,6 +136,10 @@ class BsInventoryMarker(PropertyGroup):
     )
 
 
+prn_versioned_arguments = {}
+if bpy.app.version >= (3, 3, 0):
+    prn_versioned_arguments['search'] = lambda self, context, edit_text: prn_map.get(context.scene.niftools_scene.game, [])
+
 class ObjectProperty(PropertyGroup):
 
     nodetype: EnumProperty(
@@ -147,11 +151,11 @@ class ObjectProperty(PropertyGroup):
         default='NiNode',
     )
 
+
     prn_location: StringProperty(
         name='Weapon Location',
         description='Attachment point of weapon, for Skyrim, FO3 & Oblivion',
-        search=lambda self, context, edit_text: prn_map.get(context.scene.niftools_scene.game, []),
-        # default = 'NONE'
+        **prn_versioned_arguments,
     )
 
     longname: StringProperty(


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
1. Fix to BSInvMarker rotation export.
2. Fix for bs_data_flags setting in export - now also applied to other games where applicable, not just Skyrim.
3. Fix to transform on packed collision vertices export.
4. Adjust StringProperty arguments to prevent crash in Blender 3.2 or lower.
5. Fix to mistake in BhkMalleableConstraint info import.
6. Adjustment to NiMesh import because of underlying library changes.
7. Added processing of regions to NiMesh bone import.
8. Basic DisplayList import (NiMesh with a specific type of datastream, which encodes the geometry). Bone weights for this type of nif are still unimplemented.

##  Detailed Description
-

## Fixes Known Issues
**[Ordered list of issues fixed by this PR]**

## Documentation
**[Overview of updates to documentation]**

## Testing
**[Overview of testing required to ensure functionality is correctly implemented]**

### Manual
**[Set of steps to manually verify updates are working correctly]**

### Automated
**[List of tests run, updated or added to avoid future regressions]**

## Additional Information
**[Anything else you deem relevant]**
