### PR TITLE
Reference to guide for building the `generated` module in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,4 +39,6 @@ Fork
 
 .. code-block:: shell
   
-  git clone --recursive git://github.com/niftools/blender_niftools_addon.git
+  git clone --recursive https://github.com/niftools/blender_niftools_addon.git
+
+Please check `this temporary guide <https://github.com/niftools/blender_niftools_addon/issues/566#issuecomment-1566743313>`_ for building the ``generated`` module.

--- a/docs/development/setup/environment.rst
+++ b/docs/development/setup/environment.rst
@@ -68,6 +68,10 @@ Environment Variables
     set -X BLENDER_ADDONS_DIR=<path_to_blender_addons>
     BLENDER_HOME="<path_to_blender_executable>"
 
+.. note::
+
+    If you've installed Blender from the package manager, just set it to ``/usr/bin``.
+
 **Mac**
 
 .. code-block:: shell

--- a/install/makezip.sh
+++ b/install/makezip.sh
@@ -34,6 +34,7 @@ echo "Creating dependencies folder ${DEPS_OUT:-${BUILD_DIR}/dependencies}"
 python -m pip install "PyFFI==${PYFFI_VERSION}" --target="${DEPS_OUT:-${BUILD_DIR}/dependencies}"
 
 echo "Copying loose files"
+cp -r "$GENERATED_FOLDER" "${DEPS_OUT:-${BUILD_DIR}/dependencies}/generated"
 cp "${ROOT}"/AUTHORS.rst "${ADDON_OUT}"
 cp "${ROOT}"/CHANGELOG.rst "${ADDON_OUT}"
 cp "${ROOT}"/LICENSE.rst "${ADDON_OUT}"


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
Primarily documentation update to help getting started building the project

##  Detailed Description
* Reference to guide for building the `generated` module in README
* Updated `makezip.sh`, so it can handle the `GENERATED_FOLDER` variable.
* Made a slight change to one of the development documentation files.

## Documentation
* Reference to guide for building the `generated` module in README
* Made a slight change to one of the development documentation files (just a tidbit that slightly confused me).

## Testing

### Manual
Follow the `generated` guide on Linux, and see that `makezip.sh` correctly copies the `generated` directory.