### PR TITLE
Added support for KF export for Sid Meier's Pirates!

### DIFF
--- a/io_scene_niftools/modules/nif_export/animation/__init__.py
+++ b/io_scene_niftools/modules/nif_export/animation/__init__.py
@@ -53,8 +53,11 @@ class Animation(ABC):
 
     def set_flags_and_timing(self, kfc, exp_fcurves, start_frame=None, stop_frame=None):
         # fill in the non-trivial values
-        kfc.flags = 8  # active
+        kfc.flags._value = 8  # active
         kfc.flags |= self.get_flags_from_fcurves(exp_fcurves)
+        if bpy.context.scene.niftools_scene.game == 'SID_MEIER_S_PIRATES':
+            # Sid Meier's Pirates! want the manager_controlled flag set
+            kfc.flags.manager_controlled = True
         kfc.frequency = 1.0
         kfc.phase = 0.0
         if not start_frame and not stop_frame:

--- a/io_scene_niftools/modules/nif_export/animation/transform.py
+++ b/io_scene_niftools/modules/nif_export/animation/transform.py
@@ -74,7 +74,7 @@ class TransformAnimation(Animation):
             kf_root = block_store.create_block("NiSequenceStreamHelper")
         elif game in (
                 'SKYRIM', 'OBLIVION', 'FALLOUT_3', 'CIVILIZATION_IV', 'ZOO_TYCOON_2', 'FREEDOM_FORCE_VS_THE_3RD_REICH',
-                'MEGAMI_TENSEI_IMAGINE'):
+                'MEGAMI_TENSEI_IMAGINE', 'SID_MEIER_S_PIRATES'):
             kf_root = block_store.create_block("NiControllerSequence")
         else:
             raise NifError(f"Keyframe export for '{game}' is not supported.")
@@ -109,6 +109,8 @@ class TransformAnimation(Animation):
         kf_root.weight = 1.0
         kf_root.cycle_type = NifClasses.CycleType.CYCLE_CLAMP
         kf_root.frequency = 1.0
+        if game in ('SID_MEIER_S_PIRATES',):
+            kf_root.accum_root_name = targetname
 
         if anim_textextra.num_text_keys > 0:
             kf_root.start_time = anim_textextra.text_keys[0].time


### PR DESCRIPTION
@niftools/blender-niftools-addon-reviewer 

# Overview
This adds support for exporting KF files for Sid Meier's Pirates!.

##  Detailed Description
* Manually setting the `NiKeyframeController`'s `flag`'s 32 for Pirates!, which it apparently requires.
* Setting `Accum Root Name` on the root block to the `targetname`.
* ~~Handling when Blender unsets `USER_VERSION` and `USER_VERSION_2`, when they are set to `0`.  Pirates! want these values to be 0.~~

## Testing
Be sure to set the Niftools Scene Panel's game to Sid Meier's Pirates! and user version and user version 2 to `0`.

### Manual
The basic test is to import a `kf`-file into Blender, immediately export the same `kf`-file, and place it in the game's `custom` directory.  Run the game, and find the scene where there animation would appear.

## Additional Information

Known issue: Some coordinates are slightly misaligned during import/export, and can therefore appear weird in the game, e.g. vertices moving far from their previous position and back again, giving a flickering appearance.  Most of the time, the animations look fine, but more complicated animations have a risk of these quirks.  Manually fixing these animations is probably an option.  I have not seen the issue with animations I've worked on myself.

Also, I've mostly been "hacking" my way at this, just to get it to work.  So it's possible someone else here might have a better solution for some of my additions.